### PR TITLE
refactor: `createSignedTx` not taking unsigned

### DIFF
--- a/docs/interfaces/_balancetransfer_.txinfo.md
+++ b/docs/interfaces/_balancetransfer_.txinfo.md
@@ -29,7 +29,7 @@
 
 • **address**: *string*
 
-*Defined in [src/balanceTransfer.ts:22](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/balanceTransfer.ts#L22)*
+*Defined in [src/balanceTransfer.ts:22](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/balanceTransfer.ts#L22)*
 
 The ss-58 encoded address
 
@@ -39,7 +39,7 @@ ___
 
 • **amount**: *number*
 
-*Defined in [src/balanceTransfer.ts:26](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/balanceTransfer.ts#L26)*
+*Defined in [src/balanceTransfer.ts:26](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/balanceTransfer.ts#L26)*
 
 The amount to send
 
@@ -49,7 +49,7 @@ ___
 
 • **blockHash**: *string*
 
-*Defined in [src/balanceTransfer.ts:30](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/balanceTransfer.ts#L30)*
+*Defined in [src/balanceTransfer.ts:30](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/balanceTransfer.ts#L30)*
 
 The checkpoint hash of the block, in hex
 
@@ -59,7 +59,7 @@ ___
 
 • **blockNumber**: *number*
 
-*Defined in [src/balanceTransfer.ts:34](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/balanceTransfer.ts#L34)*
+*Defined in [src/balanceTransfer.ts:34](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/balanceTransfer.ts#L34)*
 
 The checkpoint block number (u32), in hex
 
@@ -69,7 +69,7 @@ ___
 
 • **genesisHash**: *string*
 
-*Defined in [src/balanceTransfer.ts:38](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/balanceTransfer.ts#L38)*
+*Defined in [src/balanceTransfer.ts:38](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/balanceTransfer.ts#L38)*
 
 The genesis hash of the chain, in hex
 
@@ -79,7 +79,7 @@ ___
 
 • **keepAlive**? : *undefined | false | true*
 
-*Defined in [src/balanceTransfer.ts:42](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/balanceTransfer.ts#L42)*
+*Defined in [src/balanceTransfer.ts:42](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/balanceTransfer.ts#L42)*
 
 Use balances::transfer_keep_alive instead of balances::transfer
 
@@ -89,7 +89,7 @@ ___
 
 • **metadataRpc**: *string*
 
-*Defined in [src/balanceTransfer.ts:47](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/balanceTransfer.ts#L47)*
+*Defined in [src/balanceTransfer.ts:47](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/balanceTransfer.ts#L47)*
 
 The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC
 call `state_getMetadata`
@@ -100,7 +100,7 @@ ___
 
 • **nonce**: *number*
 
-*Defined in [src/balanceTransfer.ts:51](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/balanceTransfer.ts#L51)*
+*Defined in [src/balanceTransfer.ts:51](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/balanceTransfer.ts#L51)*
 
 The nonce for this transaction,
 
@@ -110,7 +110,7 @@ ___
 
 • **specVersion**: *number*
 
-*Defined in [src/balanceTransfer.ts:55](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/balanceTransfer.ts#L55)*
+*Defined in [src/balanceTransfer.ts:55](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/balanceTransfer.ts#L55)*
 
 The current spec version for the runtime
 
@@ -120,7 +120,7 @@ ___
 
 • **tip**: *number*
 
-*Defined in [src/balanceTransfer.ts:59](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/balanceTransfer.ts#L59)*
+*Defined in [src/balanceTransfer.ts:59](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/balanceTransfer.ts#L59)*
 
 The tip for this transaction, in hex
 
@@ -130,7 +130,7 @@ ___
 
 • **to**: *string*
 
-*Defined in [src/balanceTransfer.ts:63](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/balanceTransfer.ts#L63)*
+*Defined in [src/balanceTransfer.ts:63](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/balanceTransfer.ts#L63)*
 
 The recipient address, ss-58 encoded
 
@@ -140,7 +140,7 @@ ___
 
 • **validityPeriod**: *number*
 
-*Defined in [src/balanceTransfer.ts:68](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/balanceTransfer.ts#L68)*
+*Defined in [src/balanceTransfer.ts:68](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/balanceTransfer.ts#L68)*
 
 The amount of time (in second) the transaction is valid for. Will be
 translated into a mortal era

--- a/docs/interfaces/_balancetransfer_.unsignedtransaction.md
+++ b/docs/interfaces/_balancetransfer_.unsignedtransaction.md
@@ -92,7 +92,7 @@ ___
 
 • **metadataRpc**: *string*
 
-*Defined in [src/balanceTransfer.ts:15](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/balanceTransfer.ts#L15)*
+*Defined in [src/balanceTransfer.ts:15](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/balanceTransfer.ts#L15)*
 
 The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC
 call `state_getMetadata`

--- a/docs/interfaces/_decode_decodesigningpayload_.decodedsigningpayload.md
+++ b/docs/interfaces/_decode_decodesigningpayload_.decodedsigningpayload.md
@@ -1,0 +1,32 @@
+[@amaurymartiny/txwrapper](../README.md) › [Globals](../globals.md) › ["decode/decodeSigningPayload"](../modules/_decode_decodesigningpayload_.md) › [DecodedSigningPayload](_decode_decodesigningpayload_.decodedsigningpayload.md)
+
+# Interface: DecodedSigningPayload
+
+## Hierarchy
+
+* object
+
+  ↳ **DecodedSigningPayload**
+
+## Index
+
+### Properties
+
+* [era](_decode_decodesigningpayload_.decodedsigningpayload.md#era)
+* [method](_decode_decodesigningpayload_.decodedsigningpayload.md#method)
+
+## Properties
+
+###  era
+
+• **era**: *string*
+
+*Defined in [src/decode/decodeSigningPayload.ts:14](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/decode/decodeSigningPayload.ts#L14)*
+
+___
+
+###  method
+
+• **method**: *string*
+
+*Defined in [src/decode/decodeSigningPayload.ts:15](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/decode/decodeSigningPayload.ts#L15)*

--- a/docs/modules/_balancetransfer_.md
+++ b/docs/modules/_balancetransfer_.md
@@ -19,7 +19,7 @@
 
 ▸ **balanceTransfer**(`info`: [TxInfo](../interfaces/_balancetransfer_.txinfo.md)): *[UnsignedTransaction](../interfaces/_balancetransfer_.unsignedtransaction.md)*
 
-*Defined in [src/balanceTransfer.ts:78](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/balanceTransfer.ts#L78)*
+*Defined in [src/balanceTransfer.ts:78](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/balanceTransfer.ts#L78)*
 
 Construct a balance transfer transaction offline. Transactions can be
 constructed in such a way that it is valid for at least 240 minutes

--- a/docs/modules/_createsignedtx_.md
+++ b/docs/modules/_createsignedtx_.md
@@ -12,9 +12,9 @@
 
 ###  createSignedTx
 
-▸ **createSignedTx**(`unsigned`: [UnsignedTransaction](../interfaces/_balancetransfer_.unsignedtransaction.md), `signature`: string): *string*
+▸ **createSignedTx**(`address`: string, `signingPayload`: string, `signature`: string, `metadataRpc`: string): *string*
 
-*Defined in [src/createSignedTx.ts:14](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/createSignedTx.ts#L14)*
+*Defined in [src/createSignedTx.ts:15](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/createSignedTx.ts#L15)*
 
 Serialize a signed transaction in a format that can be submitted over the
 Node RPC Interface from the signing payload and signature produced by the
@@ -24,7 +24,9 @@ remote signer
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`unsigned` | [UnsignedTransaction](../interfaces/_balancetransfer_.unsignedtransaction.md) | The JSON representing the unsigned transaction |
+`address` | string | - |
+`signingPayload` | string | - |
 `signature` | string | Signature of the signing payload produced by the remote signer  |
+`metadataRpc` | string | - |
 
 **Returns:** *string*

--- a/docs/modules/_createsigningpayload_.md
+++ b/docs/modules/_createsigningpayload_.md
@@ -14,7 +14,7 @@
 
 ▸ **createSigningPayload**(`unsigned`: [UnsignedTransaction](../interfaces/_balancetransfer_.unsignedtransaction.md)): *string*
 
-*Defined in [src/createSigningPayload.ts:11](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/createSigningPayload.ts#L11)*
+*Defined in [src/createSigningPayload.ts:11](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/createSigningPayload.ts#L11)*
 
 Construct the signing payload from an unsigned transaction and export it to
 a remote signer (this is often called "detached signing")

--- a/docs/modules/_decode_decode_.md
+++ b/docs/modules/_decode_decode_.md
@@ -12,9 +12,9 @@
 
 ###  decode
 
-▸ **decode**(`data`: string, `metadataRpc`: string): *[DecodedSignedTx](_decode_decodesignedtx_.md#decodedsignedtx) | [DecodedSigningPayload](_decode_decodesigningpayload_.md#decodedsigningpayload)*
+▸ **decode**(`data`: string, `metadataRpc`: string): *[DecodedSignedTx](_decode_decodesignedtx_.md#decodedsignedtx) | [DecodedSigningPayload](../interfaces/_decode_decodesigningpayload_.decodedsigningpayload.md)*
 
-Defined in src/decode/decode.ts:14
+*Defined in [src/decode/decode.ts:14](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/decode/decode.ts#L14)*
 
 Parse the transaction information from a signing payload OR from a signed tx
 
@@ -25,4 +25,4 @@ Name | Type | Description |
 `data` | string | The data to parse, should be a signing payload or a signed tx |
 `metadataRpc` | string | The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC call `state_getMetadata`  |
 
-**Returns:** *[DecodedSignedTx](_decode_decodesignedtx_.md#decodedsignedtx) | [DecodedSigningPayload](_decode_decodesigningpayload_.md#decodedsigningpayload)*
+**Returns:** *[DecodedSignedTx](_decode_decodesignedtx_.md#decodedsignedtx) | [DecodedSigningPayload](../interfaces/_decode_decodesigningpayload_.decodedsigningpayload.md)*

--- a/docs/modules/_decode_decodesignedtx_.md
+++ b/docs/modules/_decode_decodesignedtx_.md
@@ -18,7 +18,7 @@
 
 Ƭ **DecodedSignedTx**: *Omit‹[TxInfo](../interfaces/_balancetransfer_.txinfo.md), "blockHash" | "blockNumber" | "genesisHash" | "specVersion" | "version"›*
 
-*Defined in [src/decode/decodeSignedTx.ts:9](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/decode/decodeSignedTx.ts#L9)*
+*Defined in [src/decode/decodeSignedTx.ts:9](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/decode/decodeSignedTx.ts#L9)*
 
 ## Functions
 
@@ -26,7 +26,7 @@
 
 ▸ **decodeSignedTx**(`signedTx`: string, `metadataRpc`: string): *[DecodedSignedTx](_decode_decodesignedtx_.md#decodedsignedtx)*
 
-*Defined in [src/decode/decodeSignedTx.ts:21](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/decode/decodeSignedTx.ts#L21)*
+*Defined in [src/decode/decodeSignedTx.ts:21](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/decode/decodeSignedTx.ts#L21)*
 
 Parse the transaction information from a signed transaction offline
 

--- a/docs/modules/_decode_decodesigningpayload_.md
+++ b/docs/modules/_decode_decodesigningpayload_.md
@@ -4,29 +4,21 @@
 
 ## Index
 
-### Type aliases
+### Interfaces
 
-* [DecodedSigningPayload](_decode_decodesigningpayload_.md#decodedsigningpayload)
+* [DecodedSigningPayload](../interfaces/_decode_decodesigningpayload_.decodedsigningpayload.md)
 
 ### Functions
 
 * [decodeSigningPayload](_decode_decodesigningpayload_.md#decodesigningpayload)
 
-## Type aliases
-
-###  DecodedSigningPayload
-
-Ƭ **DecodedSigningPayload**: *Omit‹[TxInfo](../interfaces/_balancetransfer_.txinfo.md), "address" | "blockNumber"›*
-
-*Defined in [src/decode/decodeSigningPayload.ts:12](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/decode/decodeSigningPayload.ts#L12)*
-
 ## Functions
 
 ###  decodeSigningPayload
 
-▸ **decodeSigningPayload**(`signingPayload`: string, `metadataRpc`: string): *[DecodedSigningPayload](_decode_decodesigningpayload_.md#decodedsigningpayload)*
+▸ **decodeSigningPayload**(`signingPayload`: string, `metadataRpc`: string): *[DecodedSigningPayload](../interfaces/_decode_decodesigningpayload_.decodedsigningpayload.md)*
 
-*Defined in [src/decode/decodeSigningPayload.ts:21](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/decode/decodeSigningPayload.ts#L21)*
+*Defined in [src/decode/decodeSigningPayload.ts:25](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/decode/decodeSigningPayload.ts#L25)*
 
 Parse the transaction information from a signing payload
 
@@ -37,4 +29,4 @@ Name | Type | Description |
 `signingPayload` | string | The signing payload, in hex |
 `metadataRpc` | string | The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC call `state_getMetadata`  |
 
-**Returns:** *[DecodedSigningPayload](_decode_decodesigningpayload_.md#decodedsigningpayload)*
+**Returns:** *[DecodedSigningPayload](../interfaces/_decode_decodesigningpayload_.decodedsigningpayload.md)*

--- a/docs/modules/_decode_decodeunsignedtx_.md
+++ b/docs/modules/_decode_decodeunsignedtx_.md
@@ -14,7 +14,7 @@
 
 ▸ **decodeUnsignedTx**(`unsigned`: [UnsignedTransaction](../interfaces/_balancetransfer_.unsignedtransaction.md), `metadataRpc`: string): *[TxInfo](../interfaces/_balancetransfer_.txinfo.md)*
 
-*Defined in [src/decode/decodeUnsignedTx.ts:15](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/decode/decodeUnsignedTx.ts#L15)*
+*Defined in [src/decode/decodeUnsignedTx.ts:15](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/decode/decodeUnsignedTx.ts#L15)*
 
 Parse the transaction information from an unigned transaction offline
 

--- a/docs/modules/_deriveaddress_.md
+++ b/docs/modules/_deriveaddress_.md
@@ -14,7 +14,7 @@
 
 ▸ **deriveAddress**(`publicKey`: string | Uint8Array, `ss58Format`: number): *string*
 
-*Defined in [src/deriveAddress.ts:11](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/deriveAddress.ts#L11)*
+*Defined in [src/deriveAddress.ts:11](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/deriveAddress.ts#L11)*
 
 Derive an address from a cryptographic public key offline
 

--- a/docs/modules/_generatekeypair_.md
+++ b/docs/modules/_generatekeypair_.md
@@ -18,7 +18,7 @@
 
 ▸ **generateKeypair**(): *[KeyringPair](../interfaces/_generatekeypair_.keyringpair.md)*
 
-*Defined in [src/generateKeypair.ts:15](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/generateKeypair.ts#L15)*
+*Defined in [src/generateKeypair.ts:15](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/generateKeypair.ts#L15)*
 
 Generate a valid public/private keypair offline
 

--- a/docs/modules/_gettxhash_.md
+++ b/docs/modules/_gettxhash_.md
@@ -14,7 +14,7 @@
 
 ▸ **getTxHash**(`signedTx`: string): *string*
 
-*Defined in [src/getTxHash.ts:8](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/getTxHash.ts#L8)*
+*Defined in [src/getTxHash.ts:8](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/getTxHash.ts#L8)*
 
 Derive the tx hash of a signed transaction offline
 

--- a/docs/modules/_util_constants_.md
+++ b/docs/modules/_util_constants_.md
@@ -18,7 +18,7 @@
 
 • **BLOCKTIME**: *6* = 6
 
-*Defined in [src/util/constants.ts:8](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/util/constants.ts#L8)*
+*Defined in [src/util/constants.ts:8](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/util/constants.ts#L8)*
 
 ___
 
@@ -26,7 +26,7 @@ ___
 
 • **EXTRINSIC_VERSION**: *4* = 4
 
-*Defined in [src/util/constants.ts:5](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/util/constants.ts#L5)*
+*Defined in [src/util/constants.ts:5](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/util/constants.ts#L5)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 • **KUSAMA_SS58_FORMAT**: *2* = 2
 
-*Defined in [src/util/constants.ts:2](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/util/constants.ts#L2)*
+*Defined in [src/util/constants.ts:2](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/util/constants.ts#L2)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • **ONE_SECOND**: *number* =  1 / BLOCKTIME
 
-*Defined in [src/util/constants.ts:9](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/util/constants.ts#L9)*
+*Defined in [src/util/constants.ts:9](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/util/constants.ts#L9)*
 
 ___
 
@@ -50,4 +50,4 @@ ___
 
 • **POLKADOT_SS58_FORMAT**: *0* = 0
 
-*Defined in [src/util/constants.ts:3](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/8a10176/src/util/constants.ts#L3)*
+*Defined in [src/util/constants.ts:3](https://github.com/amaurymartiny/polkadotjs-wrapper/blob/d55e27d/src/util/constants.ts#L3)*

--- a/src/createSignedTx.spec.ts
+++ b/src/createSignedTx.spec.ts
@@ -9,7 +9,12 @@ describe('createSignedTx', () => {
     const signingPayload = createSigningPayload(unsigned);
     const signature = await signWithAlice(signingPayload);
 
-    const tx = createSignedTx(unsigned, signature);
+    const tx = createSignedTx(
+      unsigned.address,
+      signingPayload,
+      signature,
+      unsigned.metadataRpc
+    );
     expect(tx).toBe(
       '0x2d0284ffd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d00737ecfa4c54aae9e7d00a07e6e412f149e87a7543ed9afea48e469af4cb18a9aad0819710a34eb051970d992faf8fc50884139d9b4cdc43655481c7a3aaa4700eb5808000603ff96074594cccf1cd185fa8a72ceaeefd86648f8d45514f3ce33c31bdd07e4655d30'
     );

--- a/src/createSignedTx.ts
+++ b/src/createSignedTx.ts
@@ -1,6 +1,7 @@
 import { createType, Metadata, TypeRegistry } from '@polkadot/types';
 
-import { UnsignedTransaction } from './balanceTransfer';
+import { decodeSigningPayload } from './decode/decodeSigningPayload';
+import { EXTRINSIC_VERSION } from './util/constants';
 
 /**
  * Serialize a signed transaction in a format that can be submitted over the
@@ -12,20 +13,24 @@ import { UnsignedTransaction } from './balanceTransfer';
  * signer
  */
 export function createSignedTx(
-  unsigned: UnsignedTransaction,
-  signature: string
+  address: string,
+  signingPayload: string,
+  signature: string,
+  metadataRpc: string
 ): string {
   const registry = new TypeRegistry();
-  registry.setMetadata(new Metadata(registry, unsigned.metadataRpc));
+  registry.setMetadata(new Metadata(registry, metadataRpc));
+
+  const decoded = decodeSigningPayload(signingPayload, metadataRpc);
 
   const extrinsic = createType(
     registry,
     'Extrinsic',
-    { method: unsigned.method },
-    { version: unsigned.version }
+    { method: decoded.method },
+    { version: EXTRINSIC_VERSION }
   );
 
-  extrinsic.addSignature(unsigned.address, signature, unsigned);
+  extrinsic.addSignature(address, signature, decoded);
 
   return extrinsic.toHex();
 }

--- a/src/decode/decode.spec.ts
+++ b/src/decode/decode.spec.ts
@@ -10,7 +10,12 @@ describe('decode', () => {
     const signingPayload = createSigningPayload(unsigned);
     const signature = await signWithAlice(signingPayload);
 
-    const signedTx = createSignedTx(unsigned, signature);
+    const signedTx = createSignedTx(
+      unsigned.address,
+      signingPayload,
+      signature,
+      unsigned.metadataRpc
+    );
 
     const txInfo = decode(signedTx, metadataRpc);
 

--- a/src/decode/decodeSignedTx.spec.ts
+++ b/src/decode/decodeSignedTx.spec.ts
@@ -10,7 +10,12 @@ describe('decodeSignedTx', () => {
     const signingPayload = createSigningPayload(unsigned);
     const signature = await signWithAlice(signingPayload);
 
-    const signedTx = createSignedTx(unsigned, signature);
+    const signedTx = createSignedTx(
+      unsigned.address,
+      signingPayload,
+      signature,
+      unsigned.metadataRpc
+    );
 
     const txInfo = decodeSignedTx(signedTx, metadataRpc);
 

--- a/src/decode/decodeSigningPayload.ts
+++ b/src/decode/decodeSigningPayload.ts
@@ -9,7 +9,11 @@ import {
   KUSAMA_SS58_FORMAT
 } from '../util/constants';
 
-export type DecodedSigningPayload = Omit<TxInfo, 'address' | 'blockNumber'>;
+export interface DecodedSigningPayload
+  extends Omit<TxInfo, 'address' | 'blockNumber'> {
+  era: string;
+  method: string;
+}
 
 /**
  * Parse the transaction information from a signing payload
@@ -35,9 +39,11 @@ export function decodeSigningPayload(
   return {
     amount: (method.args[1] as Compact<Balance>).toNumber(),
     blockHash: payload.blockHash.toHex(),
+    era: payload.era.toHex(),
     genesisHash: payload.genesisHash.toHex(),
     keepAlive: method.methodName === 'transferKeepAlive',
     metadataRpc,
+    method: method.toHex(),
     nonce: payload.nonce.toNumber(),
     specVersion: payload.specVersion.toNumber(),
     tip: payload.tip.toNumber(),

--- a/src/getTxHash.spec.ts
+++ b/src/getTxHash.spec.ts
@@ -9,7 +9,12 @@ describe('createSignedTx', () => {
     const unsigned = balanceTransfer(TEST_TX_INFO);
     const signingPayload = createSigningPayload(unsigned);
     const signature = await signWithAlice(signingPayload);
-    const signedTx = createSignedTx(unsigned, signature);
+    const signedTx = createSignedTx(
+      unsigned.address,
+      signingPayload,
+      signature,
+      unsigned.metadataRpc
+    );
 
     const txHash = getTxHash(signedTx);
     expect(txHash).toBe(


### PR DESCRIPTION
BREAKING CHANGE:

- `createSignedTx` has a changed signature: `createSignedTx(address: string, signingPayload: string, signature: string, metadataRpc: string): string`. In particular, the metadata is a needed argument.