### PR TITLE
Add SS58 parameter to decode suite

### DIFF
--- a/docs/interfaces/_balancetransfer_.txinfotransfer.md
+++ b/docs/interfaces/_balancetransfer_.txinfotransfer.md
@@ -33,7 +33,7 @@
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[address](_util_types_.basetxinfo.md#address)*
 
-*Defined in [src/util/types.ts:21](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L21)*
+*Defined in [src/util/types.ts:21](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L21)*
 
 The ss-58 encoded address of the sending account.
 
@@ -43,7 +43,7 @@ ___
 
 • **amount**: *number*
 
-*Defined in [src/balanceTransfer.ts:11](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/balanceTransfer.ts#L11)*
+*Defined in [src/balanceTransfer.ts:11](https://github.com/paritytech/txwrapper/blob/74e5037/src/balanceTransfer.ts#L11)*
 
 The amount to send.
 
@@ -55,7 +55,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[blockHash](_util_types_.basetxinfo.md#blockhash)*
 
-*Defined in [src/util/types.ts:25](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L25)*
+*Defined in [src/util/types.ts:25](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L25)*
 
 The checkpoint hash of the block, in hex.
 
@@ -67,7 +67,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[blockNumber](_util_types_.basetxinfo.md#blocknumber)*
 
-*Defined in [src/util/types.ts:29](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L29)*
+*Defined in [src/util/types.ts:29](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L29)*
 
 The checkpoint block number (u32), in hex.
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[genesisHash](_util_types_.basetxinfo.md#genesishash)*
 
-*Defined in [src/util/types.ts:33](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L33)*
+*Defined in [src/util/types.ts:33](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L33)*
 
 The genesis hash of the chain, in hex.
 
@@ -89,7 +89,7 @@ ___
 
 • **keepAlive**? : *undefined | false | true*
 
-*Defined in [src/balanceTransfer.ts:15](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/balanceTransfer.ts#L15)*
+*Defined in [src/balanceTransfer.ts:15](https://github.com/paritytech/txwrapper/blob/74e5037/src/balanceTransfer.ts#L15)*
 
 Use `balances::transfer_keep_alive` instead of `balances::transfer`.
 
@@ -101,7 +101,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[metadataRpc](_util_types_.basetxinfo.md#metadatarpc)*
 
-*Defined in [src/util/types.ts:38](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L38)*
+*Defined in [src/util/types.ts:38](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L38)*
 
 The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC
 call `state_getMetadata`.
@@ -114,7 +114,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[nonce](_util_types_.basetxinfo.md#nonce)*
 
-*Defined in [src/util/types.ts:42](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L42)*
+*Defined in [src/util/types.ts:42](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L42)*
 
 The nonce for this transaction.
 
@@ -126,7 +126,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[specVersion](_util_types_.basetxinfo.md#specversion)*
 
-*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L46)*
+*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L46)*
 
 The current spec version for the runtime.
 
@@ -138,7 +138,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[tip](_util_types_.basetxinfo.md#tip)*
 
-*Defined in [src/util/types.ts:50](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L50)*
+*Defined in [src/util/types.ts:50](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L50)*
 
 The tip for this transaction, in hex.
 
@@ -148,7 +148,7 @@ ___
 
 • **to**: *string*
 
-*Defined in [src/balanceTransfer.ts:19](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/balanceTransfer.ts#L19)*
+*Defined in [src/balanceTransfer.ts:19](https://github.com/paritytech/txwrapper/blob/74e5037/src/balanceTransfer.ts#L19)*
 
 The recipient address, SS-58 encoded.
 
@@ -160,7 +160,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[validityPeriod](_util_types_.basetxinfo.md#validityperiod)*
 
-*Defined in [src/util/types.ts:55](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L55)*
+*Defined in [src/util/types.ts:55](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L55)*
 
 The amount of time (in second) the transaction is valid for. Will be
 translated into a mortal era.

--- a/docs/interfaces/_staking_stakingtxtypeutils_.txinfobond.md
+++ b/docs/interfaces/_staking_stakingtxtypeutils_.txinfobond.md
@@ -33,7 +33,7 @@
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[address](_util_types_.basetxinfo.md#address)*
 
-*Defined in [src/util/types.ts:21](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L21)*
+*Defined in [src/util/types.ts:21](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L21)*
 
 The ss-58 encoded address of the sending account.
 
@@ -45,7 +45,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[blockHash](_util_types_.basetxinfo.md#blockhash)*
 
-*Defined in [src/util/types.ts:25](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L25)*
+*Defined in [src/util/types.ts:25](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L25)*
 
 The checkpoint hash of the block, in hex.
 
@@ -57,7 +57,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[blockNumber](_util_types_.basetxinfo.md#blocknumber)*
 
-*Defined in [src/util/types.ts:29](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L29)*
+*Defined in [src/util/types.ts:29](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L29)*
 
 The checkpoint block number (u32), in hex.
 
@@ -67,7 +67,7 @@ ___
 
 • **controller**: *string*
 
-*Defined in [src/staking/stakingTxTypeUtils.ts:7](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/staking/stakingTxTypeUtils.ts#L7)*
+*Defined in [src/staking/stakingTxTypeUtils.ts:7](https://github.com/paritytech/txwrapper/blob/74e5037/src/staking/stakingTxTypeUtils.ts#L7)*
 
 The SS-58 encoded address of the Controller account.
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[genesisHash](_util_types_.basetxinfo.md#genesishash)*
 
-*Defined in [src/util/types.ts:33](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L33)*
+*Defined in [src/util/types.ts:33](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L33)*
 
 The genesis hash of the chain, in hex.
 
@@ -91,7 +91,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[metadataRpc](_util_types_.basetxinfo.md#metadatarpc)*
 
-*Defined in [src/util/types.ts:38](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L38)*
+*Defined in [src/util/types.ts:38](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L38)*
 
 The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC
 call `state_getMetadata`.
@@ -104,7 +104,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[nonce](_util_types_.basetxinfo.md#nonce)*
 
-*Defined in [src/util/types.ts:42](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L42)*
+*Defined in [src/util/types.ts:42](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L42)*
 
 The nonce for this transaction.
 
@@ -114,7 +114,7 @@ ___
 
 • **payee**: *string*
 
-*Defined in [src/staking/stakingTxTypeUtils.ts:15](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/staking/stakingTxTypeUtils.ts#L15)*
+*Defined in [src/staking/stakingTxTypeUtils.ts:15](https://github.com/paritytech/txwrapper/blob/74e5037/src/staking/stakingTxTypeUtils.ts#L15)*
 
 The rewards destination. Can be "Stash", "Staked", or "Controller".
 
@@ -126,7 +126,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[specVersion](_util_types_.basetxinfo.md#specversion)*
 
-*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L46)*
+*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L46)*
 
 The current spec version for the runtime.
 
@@ -138,7 +138,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[tip](_util_types_.basetxinfo.md#tip)*
 
-*Defined in [src/util/types.ts:50](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L50)*
+*Defined in [src/util/types.ts:50](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L50)*
 
 The tip for this transaction, in hex.
 
@@ -150,7 +150,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[validityPeriod](_util_types_.basetxinfo.md#validityperiod)*
 
-*Defined in [src/util/types.ts:55](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L55)*
+*Defined in [src/util/types.ts:55](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L55)*
 
 The amount of time (in second) the transaction is valid for. Will be
 translated into a mortal era.
@@ -161,6 +161,6 @@ ___
 
 • **value**: *number*
 
-*Defined in [src/staking/stakingTxTypeUtils.ts:11](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/staking/stakingTxTypeUtils.ts#L11)*
+*Defined in [src/staking/stakingTxTypeUtils.ts:11](https://github.com/paritytech/txwrapper/blob/74e5037/src/staking/stakingTxTypeUtils.ts#L11)*
 
 The number of tokens to bond.

--- a/docs/interfaces/_staking_stakingtxtypeutils_.txinfonominate.md
+++ b/docs/interfaces/_staking_stakingtxtypeutils_.txinfonominate.md
@@ -31,7 +31,7 @@
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[address](_util_types_.basetxinfo.md#address)*
 
-*Defined in [src/util/types.ts:21](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L21)*
+*Defined in [src/util/types.ts:21](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L21)*
 
 The ss-58 encoded address of the sending account.
 
@@ -43,7 +43,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[blockHash](_util_types_.basetxinfo.md#blockhash)*
 
-*Defined in [src/util/types.ts:25](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L25)*
+*Defined in [src/util/types.ts:25](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L25)*
 
 The checkpoint hash of the block, in hex.
 
@@ -55,7 +55,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[blockNumber](_util_types_.basetxinfo.md#blocknumber)*
 
-*Defined in [src/util/types.ts:29](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L29)*
+*Defined in [src/util/types.ts:29](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L29)*
 
 The checkpoint block number (u32), in hex.
 
@@ -67,7 +67,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[genesisHash](_util_types_.basetxinfo.md#genesishash)*
 
-*Defined in [src/util/types.ts:33](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L33)*
+*Defined in [src/util/types.ts:33](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L33)*
 
 The genesis hash of the chain, in hex.
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[metadataRpc](_util_types_.basetxinfo.md#metadatarpc)*
 
-*Defined in [src/util/types.ts:38](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L38)*
+*Defined in [src/util/types.ts:38](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L38)*
 
 The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC
 call `state_getMetadata`.
@@ -92,7 +92,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[nonce](_util_types_.basetxinfo.md#nonce)*
 
-*Defined in [src/util/types.ts:42](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L42)*
+*Defined in [src/util/types.ts:42](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L42)*
 
 The nonce for this transaction.
 
@@ -104,7 +104,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[specVersion](_util_types_.basetxinfo.md#specversion)*
 
-*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L46)*
+*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L46)*
 
 The current spec version for the runtime.
 
@@ -114,7 +114,7 @@ ___
 
 • **targets**: *Array‹string›*
 
-*Defined in [src/staking/stakingTxTypeUtils.ts:25](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/staking/stakingTxTypeUtils.ts#L25)*
+*Defined in [src/staking/stakingTxTypeUtils.ts:25](https://github.com/paritytech/txwrapper/blob/74e5037/src/staking/stakingTxTypeUtils.ts#L25)*
 
 The SS-58 encoded addresses of the targets you wish to nominate. A maximum of 16
 nominations are allowed.
@@ -129,7 +129,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[tip](_util_types_.basetxinfo.md#tip)*
 
-*Defined in [src/util/types.ts:50](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L50)*
+*Defined in [src/util/types.ts:50](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L50)*
 
 The tip for this transaction, in hex.
 
@@ -141,7 +141,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[validityPeriod](_util_types_.basetxinfo.md#validityperiod)*
 
-*Defined in [src/util/types.ts:55](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L55)*
+*Defined in [src/util/types.ts:55](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L55)*
 
 The amount of time (in second) the transaction is valid for. Will be
 translated into a mortal era.

--- a/docs/interfaces/_staking_stakingtxtypeutils_.txinfounbond.md
+++ b/docs/interfaces/_staking_stakingtxtypeutils_.txinfounbond.md
@@ -31,7 +31,7 @@
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[address](_util_types_.basetxinfo.md#address)*
 
-*Defined in [src/util/types.ts:21](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L21)*
+*Defined in [src/util/types.ts:21](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L21)*
 
 The ss-58 encoded address of the sending account.
 
@@ -43,7 +43,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[blockHash](_util_types_.basetxinfo.md#blockhash)*
 
-*Defined in [src/util/types.ts:25](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L25)*
+*Defined in [src/util/types.ts:25](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L25)*
 
 The checkpoint hash of the block, in hex.
 
@@ -55,7 +55,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[blockNumber](_util_types_.basetxinfo.md#blocknumber)*
 
-*Defined in [src/util/types.ts:29](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L29)*
+*Defined in [src/util/types.ts:29](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L29)*
 
 The checkpoint block number (u32), in hex.
 
@@ -67,7 +67,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[genesisHash](_util_types_.basetxinfo.md#genesishash)*
 
-*Defined in [src/util/types.ts:33](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L33)*
+*Defined in [src/util/types.ts:33](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L33)*
 
 The genesis hash of the chain, in hex.
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[metadataRpc](_util_types_.basetxinfo.md#metadatarpc)*
 
-*Defined in [src/util/types.ts:38](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L38)*
+*Defined in [src/util/types.ts:38](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L38)*
 
 The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC
 call `state_getMetadata`.
@@ -92,7 +92,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[nonce](_util_types_.basetxinfo.md#nonce)*
 
-*Defined in [src/util/types.ts:42](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L42)*
+*Defined in [src/util/types.ts:42](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L42)*
 
 The nonce for this transaction.
 
@@ -104,7 +104,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[specVersion](_util_types_.basetxinfo.md#specversion)*
 
-*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L46)*
+*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L46)*
 
 The current spec version for the runtime.
 
@@ -116,7 +116,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[tip](_util_types_.basetxinfo.md#tip)*
 
-*Defined in [src/util/types.ts:50](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L50)*
+*Defined in [src/util/types.ts:50](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L50)*
 
 The tip for this transaction, in hex.
 
@@ -128,7 +128,7 @@ ___
 
 *Inherited from [BaseTxInfo](_util_types_.basetxinfo.md).[validityPeriod](_util_types_.basetxinfo.md#validityperiod)*
 
-*Defined in [src/util/types.ts:55](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L55)*
+*Defined in [src/util/types.ts:55](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L55)*
 
 The amount of time (in second) the transaction is valid for. Will be
 translated into a mortal era.
@@ -139,6 +139,6 @@ ___
 
 • **value**: *number*
 
-*Defined in [src/staking/stakingTxTypeUtils.ts:32](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/staking/stakingTxTypeUtils.ts#L32)*
+*Defined in [src/staking/stakingTxTypeUtils.ts:32](https://github.com/paritytech/txwrapper/blob/74e5037/src/staking/stakingTxTypeUtils.ts#L32)*
 
 The number of tokens to unbond.

--- a/docs/interfaces/_util_types_.basetxinfo.md
+++ b/docs/interfaces/_util_types_.basetxinfo.md
@@ -36,7 +36,7 @@ JSON format for information that is common to all transactions.
 
 • **address**: *string*
 
-*Defined in [src/util/types.ts:21](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L21)*
+*Defined in [src/util/types.ts:21](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L21)*
 
 The ss-58 encoded address of the sending account.
 
@@ -46,7 +46,7 @@ ___
 
 • **blockHash**: *string*
 
-*Defined in [src/util/types.ts:25](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L25)*
+*Defined in [src/util/types.ts:25](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L25)*
 
 The checkpoint hash of the block, in hex.
 
@@ -56,7 +56,7 @@ ___
 
 • **blockNumber**: *number*
 
-*Defined in [src/util/types.ts:29](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L29)*
+*Defined in [src/util/types.ts:29](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L29)*
 
 The checkpoint block number (u32), in hex.
 
@@ -66,7 +66,7 @@ ___
 
 • **genesisHash**: *string*
 
-*Defined in [src/util/types.ts:33](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L33)*
+*Defined in [src/util/types.ts:33](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L33)*
 
 The genesis hash of the chain, in hex.
 
@@ -76,7 +76,7 @@ ___
 
 • **metadataRpc**: *string*
 
-*Defined in [src/util/types.ts:38](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L38)*
+*Defined in [src/util/types.ts:38](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L38)*
 
 The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC
 call `state_getMetadata`.
@@ -87,7 +87,7 @@ ___
 
 • **nonce**: *number*
 
-*Defined in [src/util/types.ts:42](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L42)*
+*Defined in [src/util/types.ts:42](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L42)*
 
 The nonce for this transaction.
 
@@ -97,7 +97,7 @@ ___
 
 • **specVersion**: *number*
 
-*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L46)*
+*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L46)*
 
 The current spec version for the runtime.
 
@@ -107,7 +107,7 @@ ___
 
 • **tip**: *number*
 
-*Defined in [src/util/types.ts:50](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L50)*
+*Defined in [src/util/types.ts:50](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L50)*
 
 The tip for this transaction, in hex.
 
@@ -117,7 +117,7 @@ ___
 
 • **validityPeriod**: *number*
 
-*Defined in [src/util/types.ts:55](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L55)*
+*Defined in [src/util/types.ts:55](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L55)*
 
 The amount of time (in second) the transaction is valid for. Will be
 translated into a mortal era.

--- a/docs/interfaces/_util_types_.unsignedtransaction.md
+++ b/docs/interfaces/_util_types_.unsignedtransaction.md
@@ -92,7 +92,7 @@ ___
 
 • **metadataRpc**: *string*
 
-*Defined in [src/util/types.ts:11](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/types.ts#L11)*
+*Defined in [src/util/types.ts:11](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/types.ts#L11)*
 
 The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC
 call `state_getMetadata`.

--- a/docs/modules/_balancetransfer_.md
+++ b/docs/modules/_balancetransfer_.md
@@ -18,7 +18,7 @@
 
 ▸ **balanceTransfer**(`info`: [TxInfoTransfer](../interfaces/_balancetransfer_.txinfotransfer.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/balanceTransfer.ts:28](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/balanceTransfer.ts#L28)*
+*Defined in [src/balanceTransfer.ts:28](https://github.com/paritytech/txwrapper/blob/74e5037/src/balanceTransfer.ts#L28)*
 
 Construct a balance transfer transaction offline. Transactions can be
 constructed in such a way that they are valid for at least 240 minutes.

--- a/docs/modules/_createsignedtx_.md
+++ b/docs/modules/_createsignedtx_.md
@@ -14,7 +14,7 @@
 
 ▸ **createSignedTx**(`unsigned`: [UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md), `signature`: string): *string*
 
-*Defined in [src/createSignedTx.ts:14](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/createSignedTx.ts#L14)*
+*Defined in [src/createSignedTx.ts:14](https://github.com/paritytech/txwrapper/blob/74e5037/src/createSignedTx.ts#L14)*
 
 Serialize a signed transaction in a format that can be submitted over the
 Node RPC Interface from the signing payload and signature produced by the

--- a/docs/modules/_createsigningpayload_.md
+++ b/docs/modules/_createsigningpayload_.md
@@ -14,7 +14,7 @@
 
 ▸ **createSigningPayload**(`unsigned`: [UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)): *string*
 
-*Defined in [src/createSigningPayload.ts:11](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/createSigningPayload.ts#L11)*
+*Defined in [src/createSigningPayload.ts:11](https://github.com/paritytech/txwrapper/blob/74e5037/src/createSigningPayload.ts#L11)*
 
 Construct the signing payload from an unsigned transaction and export it to
 a remote signer (this is often called "detached signing").

--- a/docs/modules/_decode_decode_.md
+++ b/docs/modules/_decode_decode_.md
@@ -12,9 +12,9 @@
 
 ###  decode
 
-▸ **decode**(`unsignedTx`: [UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md), `metadataRpc`: string): *DecodedUnsignedTx*
+▸ **decode**(`unsignedTx`: [UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md), `metadataRpc`: string, `ss58Format`: number): *DecodedUnsignedTx*
 
-*Defined in [src/decode/decode.ts:16](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/decode/decode.ts#L16)*
+*Defined in [src/decode/decode.ts:17](https://github.com/paritytech/txwrapper/blob/74e5037/src/decode/decode.ts#L17)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 
@@ -23,13 +23,14 @@ Parse the transaction information from a signing payload, an unsigned tx, or a s
 Name | Type | Description |
 ------ | ------ | ------ |
 `unsignedTx` | [UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md) | The data to parse, as an unsigned tx. |
-`metadataRpc` | string | The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC call `state_getMetadata`.  |
+`metadataRpc` | string | The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC call `state_getMetadata`. |
+`ss58Format` | number | The SS-58 address encoding to return.  |
 
 **Returns:** *DecodedUnsignedTx*
 
-▸ **decode**(`signedTx`: string, `metadataRpc`: string): *DecodedSignedTx*
+▸ **decode**(`signedTx`: string, `metadataRpc`: string, `ss58Format`: number): *DecodedSignedTx*
 
-*Defined in [src/decode/decode.ts:28](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/decode/decode.ts#L28)*
+*Defined in [src/decode/decode.ts:31](https://github.com/paritytech/txwrapper/blob/74e5037/src/decode/decode.ts#L31)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 
@@ -38,13 +39,14 @@ Parse the transaction information from a signing payload, an unsigned tx, or a s
 Name | Type | Description |
 ------ | ------ | ------ |
 `signedTx` | string | The data to parse, as a signed tx hex string. |
-`metadataRpc` | string | The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC call `state_getMetadata`.  |
+`metadataRpc` | string | The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC call `state_getMetadata`. |
+`ss58Format` | number | The SS-58 address encoding to return.  |
 
 **Returns:** *DecodedSignedTx*
 
-▸ **decode**(`signingPayload`: string, `metadataRpc`: string): *DecodedSigningPayload*
+▸ **decode**(`signingPayload`: string, `metadataRpc`: string, `ss58Format`: number): *DecodedSigningPayload*
 
-*Defined in [src/decode/decode.ts:37](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/decode/decode.ts#L37)*
+*Defined in [src/decode/decode.ts:45](https://github.com/paritytech/txwrapper/blob/74e5037/src/decode/decode.ts#L45)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 
@@ -53,6 +55,7 @@ Parse the transaction information from a signing payload, an unsigned tx, or a s
 Name | Type | Description |
 ------ | ------ | ------ |
 `signingPayload` | string | The data to parse, as a signing payload hex string. |
-`metadataRpc` | string | The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC call `state_getMetadata`.  |
+`metadataRpc` | string | The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC call `state_getMetadata`. |
+`ss58Format` | number | The SS-58 address encoding to return.  |
 
 **Returns:** *DecodedSigningPayload*

--- a/docs/modules/_decode_decodeutils_.md
+++ b/docs/modules/_decode_decodeutils_.md
@@ -12,14 +12,15 @@
 
 ###  getMethodData
 
-▸ **getMethodData**(`method`: Call): *any*
+▸ **getMethodData**(`method`: Call, `ss58Format`: number): *any*
 
-*Defined in [src/decode/decodeUtils.ts:8](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/decode/decodeUtils.ts#L8)*
+*Defined in [src/decode/decodeUtils.ts:6](https://github.com/paritytech/txwrapper/blob/74e5037/src/decode/decodeUtils.ts#L6)*
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
 `method` | Call |
+`ss58Format` | number |
 
 **Returns:** *any*

--- a/docs/modules/_deriveaddress_.md
+++ b/docs/modules/_deriveaddress_.md
@@ -14,7 +14,7 @@
 
 ▸ **deriveAddress**(`publicKey`: string | Uint8Array, `ss58Format`: number): *string*
 
-*Defined in [src/deriveAddress.ts:11](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/deriveAddress.ts#L11)*
+*Defined in [src/deriveAddress.ts:11](https://github.com/paritytech/txwrapper/blob/74e5037/src/deriveAddress.ts#L11)*
 
 Derive an address from a cryptographic public key offline
 

--- a/docs/modules/_gettxhash_.md
+++ b/docs/modules/_gettxhash_.md
@@ -14,7 +14,7 @@
 
 ▸ **getTxHash**(`signedTx`: string): *string*
 
-*Defined in [src/getTxHash.ts:8](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/getTxHash.ts#L8)*
+*Defined in [src/getTxHash.ts:8](https://github.com/paritytech/txwrapper/blob/74e5037/src/getTxHash.ts#L8)*
 
 Derive the tx hash of a signed transaction offline
 

--- a/docs/modules/_importprivatekey_.md
+++ b/docs/modules/_importprivatekey_.md
@@ -18,7 +18,7 @@
 
 ▸ **importPrivateKey**(`privateKey`: string | Uint8Array, `ss58Format`: number): *[KeyringPair](../interfaces/_importprivatekey_.keyringpair.md)*
 
-*Defined in [src/importPrivateKey.ts:18](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/importPrivateKey.ts#L18)*
+*Defined in [src/importPrivateKey.ts:18](https://github.com/paritytech/txwrapper/blob/74e5037/src/importPrivateKey.ts#L18)*
 
 Import a private key and create a KeyringPair.
 

--- a/docs/modules/_staking_bond_.md
+++ b/docs/modules/_staking_bond_.md
@@ -14,7 +14,7 @@
 
 ▸ **bond**(`info`: [TxInfoBond](../interfaces/_staking_stakingtxtypeutils_.txinfobond.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/staking/bond.ts:13](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/staking/bond.ts#L13)*
+*Defined in [src/staking/bond.ts:13](https://github.com/paritytech/txwrapper/blob/74e5037/src/staking/bond.ts#L13)*
 
 Construct a transaction to bond funds and create a Stash account.
 

--- a/docs/modules/_staking_nominate_.md
+++ b/docs/modules/_staking_nominate_.md
@@ -14,7 +14,7 @@
 
 ▸ **nominate**(`info`: [TxInfoNominate](../interfaces/_staking_stakingtxtypeutils_.txinfonominate.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/staking/nominate.ts:13](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/staking/nominate.ts#L13)*
+*Defined in [src/staking/nominate.ts:13](https://github.com/paritytech/txwrapper/blob/74e5037/src/staking/nominate.ts#L13)*
 
 Construct a transaction to nominate. This must be called by the _Controller_ account.
 

--- a/docs/modules/_staking_unbond_.md
+++ b/docs/modules/_staking_unbond_.md
@@ -14,7 +14,7 @@
 
 ▸ **unbond**(`info`: [TxInfoUnbond](../interfaces/_staking_stakingtxtypeutils_.txinfounbond.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/staking/unbond.ts:14](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/staking/unbond.ts#L14)*
+*Defined in [src/staking/unbond.ts:14](https://github.com/paritytech/txwrapper/blob/74e5037/src/staking/unbond.ts#L14)*
 
 Construct a transaction to unbond funds from a Stash account. This must be called
 by the _Controller_ account.

--- a/docs/modules/_util_constants_.md
+++ b/docs/modules/_util_constants_.md
@@ -16,7 +16,7 @@
 
 • **EXTRINSIC_VERSION**: *4* = 4
 
-*Defined in [src/util/constants.ts:13](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/constants.ts#L13)*
+*Defined in [src/util/constants.ts:13](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/constants.ts#L13)*
 
 Latest extrinsic version
 
@@ -26,7 +26,7 @@ ___
 
 • **KUSAMA_SS58_FORMAT**: *2* = 2
 
-*Defined in [src/util/constants.ts:4](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/constants.ts#L4)*
+*Defined in [src/util/constants.ts:4](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/constants.ts#L4)*
 
 Prefix for SS58-encoded addresses on Kusama
 
@@ -36,6 +36,6 @@ ___
 
 • **POLKADOT_SS58_FORMAT**: *0* = 0
 
-*Defined in [src/util/constants.ts:8](https://github.com/paritytech/txwrapper/blob/fcbe6db/src/util/constants.ts#L8)*
+*Defined in [src/util/constants.ts:8](https://github.com/paritytech/txwrapper/blob/74e5037/src/util/constants.ts#L8)*
 
 Prefix for SS58-encoded addresses on Polkadot

--- a/src/decode/decode.spec.ts
+++ b/src/decode/decode.spec.ts
@@ -1,6 +1,7 @@
 import { balanceTransfer } from '../balanceTransfer';
 import { createSignedTx } from '../createSignedTx';
 import { createSigningPayload } from '../createSigningPayload';
+import { KUSAMA_SS58_FORMAT } from '../util/constants';
 import {
   metadataRpc,
   signWithAlice,
@@ -16,7 +17,7 @@ describe('decode', () => {
 
     const signedTx = createSignedTx(unsigned, signature);
 
-    const txInfo = decode(signedTx, metadataRpc);
+    const txInfo = decode(signedTx, metadataRpc, KUSAMA_SS58_FORMAT);
 
     (['address', 'metadataRpc', 'nonce', 'tip'] as const).forEach(key =>
       expect(txInfo[key]).toBe(TEST_TRANSFER_TX_INFO[key])
@@ -35,7 +36,7 @@ describe('decode', () => {
 
   it('decode unsigned tx', () => {
     const unsigned = balanceTransfer(TEST_TRANSFER_TX_INFO);
-    const txInfo = decode(unsigned, metadataRpc);
+    const txInfo = decode(unsigned, metadataRpc, KUSAMA_SS58_FORMAT);
 
     ([
       'address',
@@ -63,7 +64,7 @@ describe('decode', () => {
     const unsigned = balanceTransfer(TEST_TRANSFER_TX_INFO);
     const signingPayload = createSigningPayload(unsigned);
 
-    const txInfo = decode(signingPayload, metadataRpc);
+    const txInfo = decode(signingPayload, metadataRpc, KUSAMA_SS58_FORMAT);
 
     ([
       // 'blockHash',

--- a/src/decode/decode.ts
+++ b/src/decode/decode.ts
@@ -12,10 +12,12 @@ import { DecodedUnsignedTx, decodeUnsignedTx } from './decodeUnsignedTx';
  * @param unsignedTx - The data to parse, as an unsigned tx.
  * @param metadataRpc - The SCALE-encoded metadata, as a hex string. Can be
  * retrieved via the RPC call `state_getMetadata`.
+ * @param ss58Format - The SS-58 address encoding to return.
  */
 export function decode(
   unsignedTx: UnsignedTransaction,
-  metadataRpc: string
+  metadataRpc: string,
+  ss58Format: number
 ): DecodedUnsignedTx;
 
 /**
@@ -24,8 +26,13 @@ export function decode(
  * @param signedTx - The data to parse, as a signed tx hex string.
  * @param metadataRpc - The SCALE-encoded metadata, as a hex string. Can be
  * retrieved via the RPC call `state_getMetadata`.
+ * @param ss58Format - The SS-58 address encoding to return.
  */
-export function decode(signedTx: string, metadataRpc: string): DecodedSignedTx;
+export function decode(
+  signedTx: string,
+  metadataRpc: string,
+  ss58Format: number
+): DecodedSignedTx;
 
 /**
  * Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
@@ -33,25 +40,28 @@ export function decode(signedTx: string, metadataRpc: string): DecodedSignedTx;
  * @param signingPayload - The data to parse, as a signing payload hex string.
  * @param metadataRpc - The SCALE-encoded metadata, as a hex string. Can be
  * retrieved via the RPC call `state_getMetadata`.
+ * @param ss58Format - The SS-58 address encoding to return.
  */
 export function decode(
   signingPayload: string,
-  metadataRpc: string
+  metadataRpc: string,
+  ss58Format: number
 ): DecodedSigningPayload;
 
 export function decode(
   data: string | UnsignedTransaction,
-  metadataRpc: string
+  metadataRpc: string,
+  ss58Format: number
 ): DecodedSignedTx | DecodedUnsignedTx | DecodedSigningPayload {
   if (typeof data === 'string') {
     let decodedInfo: DecodedSigningPayload | DecodedSignedTx;
     try {
-      decodedInfo = decodeSigningPayload(data, metadataRpc);
+      decodedInfo = decodeSigningPayload(data, metadataRpc, ss58Format);
     } catch {
-      decodedInfo = decodeSignedTx(data, metadataRpc);
+      decodedInfo = decodeSignedTx(data, metadataRpc, ss58Format);
     }
     return decodedInfo;
   }
 
-  return decodeUnsignedTx(data, metadataRpc);
+  return decodeUnsignedTx(data, metadataRpc, ss58Format);
 }

--- a/src/decode/decodeSignedTx.spec.ts
+++ b/src/decode/decodeSignedTx.spec.ts
@@ -2,6 +2,7 @@ import { balanceTransfer } from '../balanceTransfer';
 import { createSignedTx } from '../createSignedTx';
 import { createSigningPayload } from '../createSigningPayload';
 import { bond } from '../staking/bond';
+import { KUSAMA_SS58_FORMAT } from '../util/constants';
 import {
   metadataRpc,
   signWithAlice,
@@ -18,7 +19,7 @@ describe('decodeSignedTx', () => {
 
     const signedTx = createSignedTx(unsigned, signature);
 
-    const txInfo = decodeSignedTx(signedTx, metadataRpc);
+    const txInfo = decodeSignedTx(signedTx, metadataRpc, KUSAMA_SS58_FORMAT);
 
     (['address', 'metadataRpc', 'nonce', 'tip'] as const).forEach(key =>
       expect(txInfo[key]).toBe(TEST_TRANSFER_TX_INFO[key])

--- a/src/decode/decodeSignedTx.ts
+++ b/src/decode/decodeSignedTx.ts
@@ -29,10 +29,12 @@ export type DecodedSignedTx = Omit<
  * @param unsigned - The JSON representing the unsigned transaction.
  * @param metadataRpc - The SCALE-encoded metadata, as a hex string. Can be
  * retrieved via the RPC call `state_getMetadata`.
+ * @param ss58Format - The SS-58 address encoding to return.
  */
 export function decodeSignedTx(
   signedTx: string,
-  metadataRpc: string
+  metadataRpc: string,
+  ss58Format: number = KUSAMA_SS58_FORMAT
 ): DecodedSignedTx {
   const registry = new TypeRegistry();
   registry.setMetadata(new Metadata(registry, metadataRpc));
@@ -41,9 +43,9 @@ export function decodeSignedTx(
     isSigned: true
   });
 
-  const methodInfo = getMethodData(tx.method);
+  const methodInfo = getMethodData(tx.method, ss58Format);
 
-  setSS58Format(KUSAMA_SS58_FORMAT);
+  setSS58Format(ss58Format);
 
   return {
     address: tx.signer.toString(),

--- a/src/decode/decodeSigningPayload.spec.ts
+++ b/src/decode/decodeSigningPayload.spec.ts
@@ -1,6 +1,7 @@
 import { balanceTransfer } from '../balanceTransfer';
 import { createSigningPayload } from '../createSigningPayload';
 import { nominate } from '../staking/nominate';
+import { KUSAMA_SS58_FORMAT } from '../util/constants';
 import {
   metadataRpc,
   TEST_NOMINATE_TX_INFO,
@@ -14,7 +15,11 @@ describe('decodeSigningPayload', () => {
       balanceTransfer(TEST_TRANSFER_TX_INFO)
     );
 
-    const txInfo = decodeSigningPayload(signingPayload, metadataRpc);
+    const txInfo = decodeSigningPayload(
+      signingPayload,
+      metadataRpc,
+      KUSAMA_SS58_FORMAT
+    );
 
     ([
       'blockHash',

--- a/src/decode/decodeSigningPayload.ts
+++ b/src/decode/decodeSigningPayload.ts
@@ -8,7 +8,11 @@
 
 import { createType, Metadata, TypeRegistry } from '@polkadot/types';
 
-import { BLOCKTIME, EXTRINSIC_VERSION } from '../util/constants';
+import {
+  BLOCKTIME,
+  EXTRINSIC_VERSION,
+  KUSAMA_SS58_FORMAT
+} from '../util/constants';
 import { BaseTxInfo } from '../util/types';
 import { getMethodData } from './decodeUtils';
 
@@ -27,10 +31,12 @@ export type DecodedSigningPayload = Omit<
  * @param signingPayload - The signing payload, in hex.
  * @param metadataRpc - The SCALE-encoded metadata, as a hex string. Can be
  * retrieved via the RPC call `state_getMetadata`.
+ * @param ss58Format - The SS-58 address encoding to return.
  */
 export function decodeSigningPayload(
   signingPayload: string,
-  metadataRpc: string
+  metadataRpc: string,
+  ss58Format: number = KUSAMA_SS58_FORMAT
 ): DecodedSigningPayload {
   const registry = new TypeRegistry();
   registry.setMetadata(new Metadata(registry, metadataRpc));
@@ -40,7 +46,7 @@ export function decodeSigningPayload(
   });
   const method = createType(registry, 'Call', payload.method);
 
-  const methodInfo = getMethodData(method);
+  const methodInfo = getMethodData(method, ss58Format);
 
   return {
     methodData: methodInfo,

--- a/src/decode/decodeUnsignedTx.spec.ts
+++ b/src/decode/decodeUnsignedTx.spec.ts
@@ -1,5 +1,6 @@
 import { balanceTransfer } from '../balanceTransfer';
 import { unbond } from '../staking/unbond';
+import { KUSAMA_SS58_FORMAT } from '../util/constants';
 import {
   metadataRpc,
   TEST_TRANSFER_TX_INFO,
@@ -10,7 +11,7 @@ import { decodeUnsignedTx } from './decodeUnsignedTx';
 describe('decodeSignedTx', () => {
   it('should decode SignedTx balance transfer', () => {
     const unsigned = balanceTransfer(TEST_TRANSFER_TX_INFO);
-    const txInfo = decodeUnsignedTx(unsigned, metadataRpc);
+    const txInfo = decodeUnsignedTx(unsigned, metadataRpc, KUSAMA_SS58_FORMAT);
 
     ([
       'address',

--- a/src/decode/decodeUnsignedTx.ts
+++ b/src/decode/decodeUnsignedTx.ts
@@ -23,19 +23,21 @@ export interface DecodedUnsignedTx extends BaseTxInfo {
  * @param unsigned - The JSON representing the unsigned transaction.
  * @param metadataRpc - The SCALE-encoded metadata, as a hex string. Can be
  * retrieved via the RPC call `state_getMetadata`.
+ * @param ss58Format - The SS-58 address encoding to return.
  */
 export function decodeUnsignedTx(
   unsigned: UnsignedTransaction,
-  metadataRpc: string
+  metadataRpc: string,
+  ss58Format: number = KUSAMA_SS58_FORMAT
 ): DecodedUnsignedTx {
   const registry = new TypeRegistry();
   registry.setMetadata(new Metadata(registry, metadataRpc));
 
   const method = createType(registry, 'Call', unsigned.method);
 
-  const methodInfo = getMethodData(method);
+  const methodInfo = getMethodData(method, ss58Format);
 
-  setSS58Format(KUSAMA_SS58_FORMAT);
+  setSS58Format(ss58Format);
 
   return {
     address: unsigned.address,

--- a/src/decode/decodeUtils.ts
+++ b/src/decode/decodeUtils.ts
@@ -3,10 +3,8 @@ import { Balance } from '@polkadot/types/interfaces';
 import Call from '@polkadot/types/primitive/Generic/Call';
 import { setSS58Format } from '@polkadot/util-crypto';
 
-import { KUSAMA_SS58_FORMAT } from '../util/constants';
-
-export function getMethodData(method: Call): any {
-  setSS58Format(KUSAMA_SS58_FORMAT);
+export function getMethodData(method: Call, ss58Format: number): any {
+  setSS58Format(ss58Format);
   if (
     method.methodName === 'transfer' ||
     method.methodName === 'transferKeepAlive'


### PR DESCRIPTION
Closes https://github.com/paritytech/txwrapper/issues/20

Does what the title says. Breaks `decode*` API.