### PR TITLE
fix: Export methods object

### DIFF
--- a/docs/interfaces/_methods_balances_transfer_.balancestransferargs.md
+++ b/docs/interfaces/_methods_balances_transfer_.balancestransferargs.md
@@ -21,7 +21,7 @@
 
 • **dest**: *string*
 
-*Defined in [src/methods/balances/transfer.ts:12](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/balances/transfer.ts#L12)*
+*Defined in [src/methods/balances/transfer.ts:12](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/balances/transfer.ts#L12)*
 
 The recipient address, SS-58 encoded.
 
@@ -31,6 +31,6 @@ ___
 
 • **value**: *number*
 
-*Defined in [src/methods/balances/transfer.ts:16](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/balances/transfer.ts#L16)*
+*Defined in [src/methods/balances/transfer.ts:16](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/balances/transfer.ts#L16)*
 
 The amount to send.

--- a/docs/interfaces/_methods_democracy_activateproxy_.democracyactivateproxyargs.md
+++ b/docs/interfaces/_methods_democracy_activateproxy_.democracyactivateproxyargs.md
@@ -20,6 +20,6 @@
 
 • **proxy**: *string*
 
-*Defined in [src/methods/democracy/activateProxy.ts:12](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/democracy/activateProxy.ts#L12)*
+*Defined in [src/methods/democracy/activateProxy.ts:12](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/democracy/activateProxy.ts#L12)*
 
 Address to set as proxy, SS-58 encoded.

--- a/docs/interfaces/_methods_democracy_deactivateproxy_.democracydeactivateproxyargs.md
+++ b/docs/interfaces/_methods_democracy_deactivateproxy_.democracydeactivateproxyargs.md
@@ -20,6 +20,6 @@
 
 • **proxy**: *string*
 
-*Defined in [src/methods/democracy/deactivateProxy.ts:12](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/democracy/deactivateProxy.ts#L12)*
+*Defined in [src/methods/democracy/deactivateProxy.ts:12](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/democracy/deactivateProxy.ts#L12)*
 
 The address of the proxy to remove, SS-58 encoded.

--- a/docs/interfaces/_methods_democracy_openproxy_.democracyopenproxyargs.md
+++ b/docs/interfaces/_methods_democracy_openproxy_.democracyopenproxyargs.md
@@ -20,6 +20,6 @@
 
 • **target**: *string*
 
-*Defined in [src/methods/democracy/openProxy.ts:12](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/democracy/openProxy.ts#L12)*
+*Defined in [src/methods/democracy/openProxy.ts:12](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/democracy/openProxy.ts#L12)*
 
 The address of the proxy to remove, SS-58 encoded.

--- a/docs/interfaces/_methods_democracy_proxyvote_.democracyproxyvoteargs.md
+++ b/docs/interfaces/_methods_democracy_proxyvote_.democracyproxyvoteargs.md
@@ -21,7 +21,7 @@
 
 • **refIndex**: *number*
 
-*Defined in [src/methods/democracy/proxyVote.ts:13](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/democracy/proxyVote.ts#L13)*
+*Defined in [src/methods/democracy/proxyVote.ts:13](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/democracy/proxyVote.ts#L13)*
 
 ___
 
@@ -29,6 +29,6 @@ ___
 
 • **vote**: *[Vote](../modules/_methods_democracy_types_.md#vote)*
 
-*Defined in [src/methods/democracy/proxyVote.ts:18](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/democracy/proxyVote.ts#L18)*
+*Defined in [src/methods/democracy/proxyVote.ts:18](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/democracy/proxyVote.ts#L18)*
 
 Vote

--- a/docs/interfaces/_methods_democracy_vote_.democracyvoteargs.md
+++ b/docs/interfaces/_methods_democracy_vote_.democracyvoteargs.md
@@ -21,7 +21,7 @@
 
 • **refIndex**: *number*
 
-*Defined in [src/methods/democracy/vote.ts:13](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/democracy/vote.ts#L13)*
+*Defined in [src/methods/democracy/vote.ts:13](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/democracy/vote.ts#L13)*
 
 ___
 
@@ -29,6 +29,6 @@ ___
 
 • **vote**: *[Vote](../modules/_methods_democracy_types_.md#vote)*
 
-*Defined in [src/methods/democracy/vote.ts:18](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/democracy/vote.ts#L18)*
+*Defined in [src/methods/democracy/vote.ts:18](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/democracy/vote.ts#L18)*
 
 Vote

--- a/docs/interfaces/_methods_session_setkeys_.sessionsetkeysargs.md
+++ b/docs/interfaces/_methods_session_setkeys_.sessionsetkeysargs.md
@@ -21,7 +21,7 @@
 
 • **keys**: *string[]*
 
-*Defined in [src/methods/session/setKeys.ts:12](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/session/setKeys.ts#L12)*
+*Defined in [src/methods/session/setKeys.ts:12](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/session/setKeys.ts#L12)*
 
 The 5 keys to set.
 
@@ -31,6 +31,6 @@ ___
 
 • **proof**? : *undefined | string*
 
-*Defined in [src/methods/session/setKeys.ts:16](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/session/setKeys.ts#L16)*
+*Defined in [src/methods/session/setKeys.ts:16](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/session/setKeys.ts#L16)*
 
 Proof (unused for now).

--- a/docs/interfaces/_methods_staking_bond_.stakingbondargs.md
+++ b/docs/interfaces/_methods_staking_bond_.stakingbondargs.md
@@ -22,7 +22,7 @@
 
 • **controller**: *string*
 
-*Defined in [src/methods/staking/bond.ts:12](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/bond.ts#L12)*
+*Defined in [src/methods/staking/bond.ts:12](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/bond.ts#L12)*
 
 The SS-58 encoded address of the Controller account.
 
@@ -32,7 +32,7 @@ ___
 
 • **payee**: *string*
 
-*Defined in [src/methods/staking/bond.ts:20](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/bond.ts#L20)*
+*Defined in [src/methods/staking/bond.ts:20](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/bond.ts#L20)*
 
 The rewards destination. Can be "Stash", "Staked", or "Controller".
 
@@ -42,6 +42,6 @@ ___
 
 • **value**: *number*
 
-*Defined in [src/methods/staking/bond.ts:16](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/bond.ts#L16)*
+*Defined in [src/methods/staking/bond.ts:16](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/bond.ts#L16)*
 
 The number of tokens to bond.

--- a/docs/interfaces/_methods_staking_bondextra_.stakingbondextraargs.md
+++ b/docs/interfaces/_methods_staking_bondextra_.stakingbondextraargs.md
@@ -20,6 +20,6 @@
 
 • **maxAdditional**: *number*
 
-*Defined in [src/methods/staking/bondExtra.ts:12](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/bondExtra.ts#L12)*
+*Defined in [src/methods/staking/bondExtra.ts:12](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/bondExtra.ts#L12)*
 
 The maximum amount to bond.

--- a/docs/interfaces/_methods_staking_nominate_.stakingnominateargs.md
+++ b/docs/interfaces/_methods_staking_nominate_.stakingnominateargs.md
@@ -20,7 +20,7 @@
 
 • **targets**: *Array‹string›*
 
-*Defined in [src/methods/staking/nominate.ts:15](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/nominate.ts#L15)*
+*Defined in [src/methods/staking/nominate.ts:15](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/nominate.ts#L15)*
 
 The SS-58 encoded addresses of the targets you wish to nominate. A maximum of 16
 nominations are allowed.

--- a/docs/interfaces/_methods_staking_payoutnominator_.stakingpayoutnominatorargs.md
+++ b/docs/interfaces/_methods_staking_payoutnominator_.stakingpayoutnominatorargs.md
@@ -21,7 +21,7 @@
 
 • **era**: *number*
 
-*Defined in [src/methods/staking/payoutNominator.ts:14](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/payoutNominator.ts#L14)*
+*Defined in [src/methods/staking/payoutNominator.ts:14](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/payoutNominator.ts#L14)*
 
 May not be lower than one following the most recently paid era. If it is
 higher, then it indicates an instruction to skip the payout of all
@@ -33,7 +33,7 @@ ___
 
 • **validators**: *[string, number][]*
 
-*Defined in [src/methods/staking/payoutNominator.ts:21](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/payoutNominator.ts#L21)*
+*Defined in [src/methods/staking/payoutNominator.ts:21](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/payoutNominator.ts#L21)*
 
 List of all validators that `who` had exposure to during `era` alongside
 the index of the `who` in the clipped exposure of the validator. i.e. each

--- a/docs/interfaces/_methods_staking_payoutvalidator_.stakingpayoutvalidatorargs.md
+++ b/docs/interfaces/_methods_staking_payoutvalidator_.stakingpayoutvalidatorargs.md
@@ -20,7 +20,7 @@
 
 • **era**: *number*
 
-*Defined in [src/methods/staking/payoutValidator.ts:14](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/payoutValidator.ts#L14)*
+*Defined in [src/methods/staking/payoutValidator.ts:14](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/payoutValidator.ts#L14)*
 
 May not be lower than one following the most recently paid era. If it is
 higher, then it indicates an instruction to skip the payout of all

--- a/docs/interfaces/_methods_staking_setcontroller_.stakingsetcontrollerargs.md
+++ b/docs/interfaces/_methods_staking_setcontroller_.stakingsetcontrollerargs.md
@@ -20,6 +20,6 @@
 
 • **controller**: *string*
 
-*Defined in [src/methods/staking/setController.ts:12](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/setController.ts#L12)*
+*Defined in [src/methods/staking/setController.ts:12](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/setController.ts#L12)*
 
 The SS-58 encoded controller address.

--- a/docs/interfaces/_methods_staking_unbond_.stakingunbondargs.md
+++ b/docs/interfaces/_methods_staking_unbond_.stakingunbondargs.md
@@ -20,6 +20,6 @@
 
 • **value**: *number*
 
-*Defined in [src/methods/staking/unbond.ts:12](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/unbond.ts#L12)*
+*Defined in [src/methods/staking/unbond.ts:12](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/unbond.ts#L12)*
 
 The number of tokens to unbond.

--- a/docs/interfaces/_methods_staking_validate_.stakingvalidateargs.md
+++ b/docs/interfaces/_methods_staking_validate_.stakingvalidateargs.md
@@ -20,7 +20,7 @@
 
 • **prefs**: *object*
 
-*Defined in [src/methods/staking/validate.ts:12](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/validate.ts#L12)*
+*Defined in [src/methods/staking/validate.ts:12](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/validate.ts#L12)*
 
 Set the desired commission for the validator. Value is Perbill.
 

--- a/docs/interfaces/_methods_vesting_vestother_.vestingvestotherargs.md
+++ b/docs/interfaces/_methods_vesting_vestother_.vestingvestotherargs.md
@@ -20,7 +20,7 @@
 
 • **target**: *string*
 
-*Defined in [src/methods/vesting/vestOther.ts:13](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/vesting/vestOther.ts#L13)*
+*Defined in [src/methods/vesting/vestOther.ts:13](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/vesting/vestOther.ts#L13)*
 
 The account whose vested funds should be unlocked. Must have funds still
 locked under this module.

--- a/docs/interfaces/_util_types_.basetxinfo.md
+++ b/docs/interfaces/_util_types_.basetxinfo.md
@@ -28,7 +28,7 @@ JSON format for information that is common to all transactions.
 
 • **address**: *string*
 
-*Defined in [src/util/types.ts:21](https://github.com/paritytech/txwrapper/blob/4462996/src/util/types.ts#L21)*
+*Defined in [src/util/types.ts:21](https://github.com/paritytech/txwrapper/blob/32e6680/src/util/types.ts#L21)*
 
 The ss-58 encoded address of the sending account.
 
@@ -38,7 +38,7 @@ ___
 
 • **blockHash**: *string*
 
-*Defined in [src/util/types.ts:25](https://github.com/paritytech/txwrapper/blob/4462996/src/util/types.ts#L25)*
+*Defined in [src/util/types.ts:25](https://github.com/paritytech/txwrapper/blob/32e6680/src/util/types.ts#L25)*
 
 The checkpoint hash of the block, in hex.
 
@@ -48,7 +48,7 @@ ___
 
 • **blockNumber**: *number*
 
-*Defined in [src/util/types.ts:29](https://github.com/paritytech/txwrapper/blob/4462996/src/util/types.ts#L29)*
+*Defined in [src/util/types.ts:29](https://github.com/paritytech/txwrapper/blob/32e6680/src/util/types.ts#L29)*
 
 The checkpoint block number (u32), in hex.
 
@@ -58,7 +58,7 @@ ___
 
 • **genesisHash**: *string*
 
-*Defined in [src/util/types.ts:33](https://github.com/paritytech/txwrapper/blob/4462996/src/util/types.ts#L33)*
+*Defined in [src/util/types.ts:33](https://github.com/paritytech/txwrapper/blob/32e6680/src/util/types.ts#L33)*
 
 The genesis hash of the chain, in hex.
 
@@ -68,7 +68,7 @@ ___
 
 • **metadataRpc**: *string*
 
-*Defined in [src/util/types.ts:38](https://github.com/paritytech/txwrapper/blob/4462996/src/util/types.ts#L38)*
+*Defined in [src/util/types.ts:38](https://github.com/paritytech/txwrapper/blob/32e6680/src/util/types.ts#L38)*
 
 The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC
 call `state_getMetadata`.
@@ -79,7 +79,7 @@ ___
 
 • **nonce**: *number*
 
-*Defined in [src/util/types.ts:42](https://github.com/paritytech/txwrapper/blob/4462996/src/util/types.ts#L42)*
+*Defined in [src/util/types.ts:42](https://github.com/paritytech/txwrapper/blob/32e6680/src/util/types.ts#L42)*
 
 The nonce for this transaction.
 
@@ -89,7 +89,7 @@ ___
 
 • **specVersion**: *number*
 
-*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/4462996/src/util/types.ts#L46)*
+*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/32e6680/src/util/types.ts#L46)*
 
 The current spec version for the runtime.
 
@@ -99,7 +99,7 @@ ___
 
 • **tip**? : *undefined | number*
 
-*Defined in [src/util/types.ts:52](https://github.com/paritytech/txwrapper/blob/4462996/src/util/types.ts#L52)*
+*Defined in [src/util/types.ts:52](https://github.com/paritytech/txwrapper/blob/32e6680/src/util/types.ts#L52)*
 
 The tip for this transaction, in hex.
 
@@ -111,7 +111,7 @@ ___
 
 • **validityPeriod**? : *undefined | number*
 
-*Defined in [src/util/types.ts:59](https://github.com/paritytech/txwrapper/blob/4462996/src/util/types.ts#L59)*
+*Defined in [src/util/types.ts:59](https://github.com/paritytech/txwrapper/blob/32e6680/src/util/types.ts#L59)*
 
 The amount of time (in second) the transaction is valid for. Will be
 translated into a mortal era. Defaults to 5 minutes.

--- a/docs/interfaces/_util_types_.unsignedtransaction.md
+++ b/docs/interfaces/_util_types_.unsignedtransaction.md
@@ -92,7 +92,7 @@ ___
 
 • **metadataRpc**: *string*
 
-*Defined in [src/util/types.ts:11](https://github.com/paritytech/txwrapper/blob/4462996/src/util/types.ts#L11)*
+*Defined in [src/util/types.ts:11](https://github.com/paritytech/txwrapper/blob/32e6680/src/util/types.ts#L11)*
 
 The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC
 call `state_getMetadata`.

--- a/docs/modules/_createsignedtx_.md
+++ b/docs/modules/_createsignedtx_.md
@@ -14,7 +14,7 @@
 
 ▸ **createSignedTx**(`unsigned`: [UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md), `signature`: string): *string*
 
-*Defined in [src/createSignedTx.ts:14](https://github.com/paritytech/txwrapper/blob/4462996/src/createSignedTx.ts#L14)*
+*Defined in [src/createSignedTx.ts:14](https://github.com/paritytech/txwrapper/blob/32e6680/src/createSignedTx.ts#L14)*
 
 Serialize a signed transaction in a format that can be submitted over the
 Node RPC Interface from the signing payload and signature produced by the

--- a/docs/modules/_createsigningpayload_.md
+++ b/docs/modules/_createsigningpayload_.md
@@ -14,7 +14,7 @@
 
 ▸ **createSigningPayload**(`unsigned`: [UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)): *string*
 
-*Defined in [src/createSigningPayload.ts:11](https://github.com/paritytech/txwrapper/blob/4462996/src/createSigningPayload.ts#L11)*
+*Defined in [src/createSigningPayload.ts:11](https://github.com/paritytech/txwrapper/blob/32e6680/src/createSigningPayload.ts#L11)*
 
 Construct the signing payload from an unsigned transaction and export it to
 a remote signer (this is often called "detached signing").

--- a/docs/modules/_decode_decode_.md
+++ b/docs/modules/_decode_decode_.md
@@ -14,7 +14,7 @@
 
 ▸ **decode**(`unsignedTx`: [UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md), `metadataRpc`: string, `ss58Format?`: undefined | number): *DecodedUnsignedTx*
 
-*Defined in [src/decode/decode.ts:18](https://github.com/paritytech/txwrapper/blob/4462996/src/decode/decode.ts#L18)*
+*Defined in [src/decode/decode.ts:18](https://github.com/paritytech/txwrapper/blob/32e6680/src/decode/decode.ts#L18)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 
@@ -30,7 +30,7 @@ Name | Type | Description |
 
 ▸ **decode**(`signedTx`: string, `metadataRpc`: string, `ss58Format?`: undefined | number): *DecodedSignedTx*
 
-*Defined in [src/decode/decode.ts:32](https://github.com/paritytech/txwrapper/blob/4462996/src/decode/decode.ts#L32)*
+*Defined in [src/decode/decode.ts:32](https://github.com/paritytech/txwrapper/blob/32e6680/src/decode/decode.ts#L32)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 
@@ -46,7 +46,7 @@ Name | Type | Description |
 
 ▸ **decode**(`signingPayload`: string, `metadataRpc`: string, `ss58Format?`: undefined | number): *DecodedSigningPayload*
 
-*Defined in [src/decode/decode.ts:46](https://github.com/paritytech/txwrapper/blob/4462996/src/decode/decode.ts#L46)*
+*Defined in [src/decode/decode.ts:46](https://github.com/paritytech/txwrapper/blob/32e6680/src/decode/decode.ts#L46)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 

--- a/docs/modules/_deriveaddress_.md
+++ b/docs/modules/_deriveaddress_.md
@@ -14,7 +14,7 @@
 
 ▸ **deriveAddress**(`publicKey`: string | Uint8Array, `ss58Format`: number): *string*
 
-*Defined in [src/deriveAddress.ts:11](https://github.com/paritytech/txwrapper/blob/4462996/src/deriveAddress.ts#L11)*
+*Defined in [src/deriveAddress.ts:11](https://github.com/paritytech/txwrapper/blob/32e6680/src/deriveAddress.ts#L11)*
 
 Derive an address from a cryptographic public key offline.
 

--- a/docs/modules/_gettxhash_.md
+++ b/docs/modules/_gettxhash_.md
@@ -14,7 +14,7 @@
 
 ▸ **getTxHash**(`signedTx`: string): *string*
 
-*Defined in [src/getTxHash.ts:8](https://github.com/paritytech/txwrapper/blob/4462996/src/getTxHash.ts#L8)*
+*Defined in [src/getTxHash.ts:8](https://github.com/paritytech/txwrapper/blob/32e6680/src/getTxHash.ts#L8)*
 
 Derive the tx hash of a signed transaction offline.
 

--- a/docs/modules/_importprivatekey_.md
+++ b/docs/modules/_importprivatekey_.md
@@ -18,7 +18,7 @@
 
 Ƭ **KeyringPair**: *KeyringPairBase*
 
-*Defined in [src/importPrivateKey.ts:10](https://github.com/paritytech/txwrapper/blob/4462996/src/importPrivateKey.ts#L10)*
+*Defined in [src/importPrivateKey.ts:10](https://github.com/paritytech/txwrapper/blob/32e6680/src/importPrivateKey.ts#L10)*
 
 A keyring pair
 
@@ -28,7 +28,7 @@ A keyring pair
 
 ▸ **importPrivateKey**(`privateKey`: string | Uint8Array, `ss58Format`: number): *KeyringPair*
 
-*Defined in [src/importPrivateKey.ts:18](https://github.com/paritytech/txwrapper/blob/4462996/src/importPrivateKey.ts#L18)*
+*Defined in [src/importPrivateKey.ts:18](https://github.com/paritytech/txwrapper/blob/32e6680/src/importPrivateKey.ts#L18)*
 
 Import a private key and create a KeyringPair.
 

--- a/docs/modules/_methods_balances_transfer_.md
+++ b/docs/modules/_methods_balances_transfer_.md
@@ -18,7 +18,7 @@
 
 ▸ **transfer**(`args`: [BalancesTransferArgs](../interfaces/_methods_balances_transfer_.balancestransferargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/balances/transfer.ts:24](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/balances/transfer.ts#L24)*
+*Defined in [src/methods/balances/transfer.ts:24](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/balances/transfer.ts#L24)*
 
 Construct a balance transfer transaction offline.
 

--- a/docs/modules/_methods_balances_transferkeepalive_.md
+++ b/docs/modules/_methods_balances_transferkeepalive_.md
@@ -18,7 +18,7 @@
 
 Ƭ **BalancesTransferKeepAliveArgs**: *[BalancesTransferArgs](../interfaces/_methods_balances_transfer_.balancestransferargs.md)*
 
-*Defined in [src/methods/balances/transferKeepAlive.ts:4](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/balances/transferKeepAlive.ts#L4)*
+*Defined in [src/methods/balances/transferKeepAlive.ts:4](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/balances/transferKeepAlive.ts#L4)*
 
 ## Functions
 
@@ -26,7 +26,7 @@
 
 ▸ **transferKeepAlive**(`args`: [BalancesTransferKeepAliveArgs](_methods_balances_transferkeepalive_.md#balancestransferkeepaliveargs), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/balances/transferKeepAlive.ts:11](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/balances/transferKeepAlive.ts#L11)*
+*Defined in [src/methods/balances/transferKeepAlive.ts:11](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/balances/transferKeepAlive.ts#L11)*
 
 Construct a balance transfer transaction offline.
 

--- a/docs/modules/_methods_democracy_activateproxy_.md
+++ b/docs/modules/_methods_democracy_activateproxy_.md
@@ -18,7 +18,7 @@
 
 ▸ **activateProxy**(`args`: [DemocracyActivateProxyArgs](../interfaces/_methods_democracy_activateproxy_.democracyactivateproxyargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/activateProxy.ts:20](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/democracy/activateProxy.ts#L20)*
+*Defined in [src/methods/democracy/activateProxy.ts:20](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/democracy/activateProxy.ts#L20)*
 
 Specify a proxy that is already open to us. Called by the stash.
 

--- a/docs/modules/_methods_democracy_closeproxy_.md
+++ b/docs/modules/_methods_democracy_closeproxy_.md
@@ -14,7 +14,7 @@
 
 ▸ **closeProxy**(`args`: object, `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/closeProxy.ts:8](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/democracy/closeProxy.ts#L8)*
+*Defined in [src/methods/democracy/closeProxy.ts:8](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/democracy/closeProxy.ts#L8)*
 
 Clear the proxy. Called by the proxy.
 

--- a/docs/modules/_methods_democracy_deactivateproxy_.md
+++ b/docs/modules/_methods_democracy_deactivateproxy_.md
@@ -18,7 +18,7 @@
 
 ▸ **deactivateProxy**(`args`: [DemocracyDeactivateProxyArgs](../interfaces/_methods_democracy_deactivateproxy_.democracydeactivateproxyargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/deactivateProxy.ts:21](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/democracy/deactivateProxy.ts#L21)*
+*Defined in [src/methods/democracy/deactivateProxy.ts:21](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/democracy/deactivateProxy.ts#L21)*
 
 Deactivate the proxy, but leave open to this account. Called by the stash.
 The proxy must already be active.

--- a/docs/modules/_methods_democracy_openproxy_.md
+++ b/docs/modules/_methods_democracy_openproxy_.md
@@ -18,7 +18,7 @@
 
 ▸ **openProxy**(`args`: [DemocracyOpenProxyArgs](../interfaces/_methods_democracy_openproxy_.democracyopenproxyargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/openProxy.ts:20](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/democracy/openProxy.ts#L20)*
+*Defined in [src/methods/democracy/openProxy.ts:20](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/democracy/openProxy.ts#L20)*
 
 Become a proxy. This must be called prior to a later `activateProxy`.
 

--- a/docs/modules/_methods_democracy_proxyvote_.md
+++ b/docs/modules/_methods_democracy_proxyvote_.md
@@ -18,7 +18,7 @@
 
 ▸ **proxyVote**(`args`: [DemocracyProxyVoteArgs](../interfaces/_methods_democracy_proxyvote_.democracyproxyvoteargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/proxyVote.ts:26](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/democracy/proxyVote.ts#L26)*
+*Defined in [src/methods/democracy/proxyVote.ts:26](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/democracy/proxyVote.ts#L26)*
 
 Vote in a referendum on behalf of a stash.
 

--- a/docs/modules/_methods_democracy_types_.md
+++ b/docs/modules/_methods_democracy_types_.md
@@ -14,7 +14,7 @@
 
 Ƭ **Vote**: *object*
 
-*Defined in [src/methods/democracy/types.ts:4](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/democracy/types.ts#L4)*
+*Defined in [src/methods/democracy/types.ts:4](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/democracy/types.ts#L4)*
 
 A vote in a referendum
 

--- a/docs/modules/_methods_democracy_vote_.md
+++ b/docs/modules/_methods_democracy_vote_.md
@@ -18,7 +18,7 @@
 
 ▸ **vote**(`args`: [DemocracyVoteArgs](../interfaces/_methods_democracy_vote_.democracyvoteargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/vote.ts:26](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/democracy/vote.ts#L26)*
+*Defined in [src/methods/democracy/vote.ts:26](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/democracy/vote.ts#L26)*
 
 Vote in a referendum.
 

--- a/docs/modules/_methods_session_setkeys_.md
+++ b/docs/modules/_methods_session_setkeys_.md
@@ -18,7 +18,7 @@
 
 ▸ **setKeys**(`args`: [SessionSetKeysArgs](../interfaces/_methods_session_setkeys_.sessionsetkeysargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/session/setKeys.ts:24](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/session/setKeys.ts#L24)*
+*Defined in [src/methods/session/setKeys.ts:24](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/session/setKeys.ts#L24)*
 
 Sets the session key(s) of the function caller to `key`.
 

--- a/docs/modules/_methods_staking_bond_.md
+++ b/docs/modules/_methods_staking_bond_.md
@@ -18,7 +18,7 @@
 
 ▸ **bond**(`args`: [StakingBondArgs](../interfaces/_methods_staking_bond_.stakingbondargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/bond.ts:28](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/bond.ts#L28)*
+*Defined in [src/methods/staking/bond.ts:28](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/bond.ts#L28)*
 
 Construct a transaction to bond funds and create a Stash account.
 

--- a/docs/modules/_methods_staking_bondextra_.md
+++ b/docs/modules/_methods_staking_bondextra_.md
@@ -18,7 +18,7 @@
 
 ▸ **bondExtra**(`args`: [StakingBondExtraArgs](../interfaces/_methods_staking_bondextra_.stakingbondextraargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/bondExtra.ts:21](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/bondExtra.ts#L21)*
+*Defined in [src/methods/staking/bondExtra.ts:21](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/bondExtra.ts#L21)*
 
 Add some extra amount that have appeared in the stash `free_balance` into
 the balance up for staking.

--- a/docs/modules/_methods_staking_chill_.md
+++ b/docs/modules/_methods_staking_chill_.md
@@ -14,7 +14,7 @@
 
 ▸ **chill**(`args`: object, `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/chill.ts:8](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/chill.ts#L8)*
+*Defined in [src/methods/staking/chill.ts:8](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/chill.ts#L8)*
 
 Declare the desire to cease validating or nominating. Does not unbond funds.
 

--- a/docs/modules/_methods_staking_nominate_.md
+++ b/docs/modules/_methods_staking_nominate_.md
@@ -18,7 +18,7 @@
 
 ▸ **nominate**(`args`: [StakingNominateArgs](../interfaces/_methods_staking_nominate_.stakingnominateargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/nominate.ts:23](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/nominate.ts#L23)*
+*Defined in [src/methods/staking/nominate.ts:23](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/nominate.ts#L23)*
 
 Construct a transaction to nominate. This must be called by the _Controller_ account.
 

--- a/docs/modules/_methods_staking_payoutnominator_.md
+++ b/docs/modules/_methods_staking_payoutnominator_.md
@@ -18,7 +18,7 @@
 
 ▸ **payoutNominator**(`args`: [StakingPayoutNominatorArgs](../interfaces/_methods_staking_payoutnominator_.stakingpayoutnominatorargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/payoutNominator.ts:32](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/payoutNominator.ts#L32)*
+*Defined in [src/methods/staking/payoutNominator.ts:32](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/payoutNominator.ts#L32)*
 
 Make one nominator's payout for one era.
 WARNING: once an era is payed for a validator such validator can't claim the

--- a/docs/modules/_methods_staking_payoutvalidator_.md
+++ b/docs/modules/_methods_staking_payoutvalidator_.md
@@ -18,7 +18,7 @@
 
 ▸ **payoutValidator**(`args`: [StakingPayoutValidatorArgs](../interfaces/_methods_staking_payoutvalidator_.stakingpayoutvalidatorargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/payoutValidator.ts:25](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/payoutValidator.ts#L25)*
+*Defined in [src/methods/staking/payoutValidator.ts:25](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/payoutValidator.ts#L25)*
 
 Make one validator's payout for one era.
 WARNING: once an era is payed for a validator such validator can't claim the

--- a/docs/modules/_methods_staking_setcontroller_.md
+++ b/docs/modules/_methods_staking_setcontroller_.md
@@ -18,7 +18,7 @@
 
 ▸ **setController**(`args`: [StakingSetControllerArgs](../interfaces/_methods_staking_setcontroller_.stakingsetcontrollerargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/setController.ts:21](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/setController.ts#L21)*
+*Defined in [src/methods/staking/setController.ts:21](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/setController.ts#L21)*
 
 (Re-)set the controller of a stash. Effects will be felt at the beginning of
 the next era.

--- a/docs/modules/_methods_staking_unbond_.md
+++ b/docs/modules/_methods_staking_unbond_.md
@@ -18,7 +18,7 @@
 
 ▸ **unbond**(`args`: [StakingUnbondArgs](../interfaces/_methods_staking_unbond_.stakingunbondargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/unbond.ts:21](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/unbond.ts#L21)*
+*Defined in [src/methods/staking/unbond.ts:21](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/unbond.ts#L21)*
 
 Construct a transaction to unbond funds from a Stash account. This must be called
 by the _Controller_ account.

--- a/docs/modules/_methods_staking_validate_.md
+++ b/docs/modules/_methods_staking_validate_.md
@@ -18,7 +18,7 @@
 
 ▸ **validate**(`args`: [StakingValidateArgs](../interfaces/_methods_staking_validate_.stakingvalidateargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/validate.ts:22](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/validate.ts#L22)*
+*Defined in [src/methods/staking/validate.ts:22](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/validate.ts#L22)*
 
 Declare the desire to validate for the origin controller.
 

--- a/docs/modules/_methods_staking_withdrawunbonded_.md
+++ b/docs/modules/_methods_staking_withdrawunbonded_.md
@@ -14,7 +14,7 @@
 
 ▸ **withdrawUnbonded**(`args`: object, `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/withdrawUnbonded.ts:8](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/staking/withdrawUnbonded.ts#L8)*
+*Defined in [src/methods/staking/withdrawUnbonded.ts:8](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/staking/withdrawUnbonded.ts#L8)*
 
 Remove any unlocked chunks from the `unlocking` queue from our management.
 

--- a/docs/modules/_methods_vesting_vest_.md
+++ b/docs/modules/_methods_vesting_vest_.md
@@ -14,7 +14,7 @@
 
 ▸ **vest**(`args`: object, `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/vesting/vest.ts:8](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/vesting/vest.ts#L8)*
+*Defined in [src/methods/vesting/vest.ts:8](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/vesting/vest.ts#L8)*
 
 Unlock any vested funds of the sender account.
 

--- a/docs/modules/_methods_vesting_vestother_.md
+++ b/docs/modules/_methods_vesting_vestother_.md
@@ -18,7 +18,7 @@
 
 ▸ **vestOther**(`args`: [VestingVestOtherArgs](../interfaces/_methods_vesting_vestother_.vestingvestotherargs.md), `info`: [BaseTxInfo](../interfaces/_util_types_.basetxinfo.md)): *[UnsignedTransaction](../interfaces/_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/vesting/vestOther.ts:21](https://github.com/paritytech/txwrapper/blob/4462996/src/methods/vesting/vestOther.ts#L21)*
+*Defined in [src/methods/vesting/vestOther.ts:21](https://github.com/paritytech/txwrapper/blob/32e6680/src/methods/vesting/vestOther.ts#L21)*
 
 Unlock any vested funds of a `target` account.
 

--- a/docs/modules/_util_constants_.md
+++ b/docs/modules/_util_constants_.md
@@ -16,7 +16,7 @@
 
 • **EXTRINSIC_VERSION**: *4* = 4
 
-*Defined in [src/util/constants.ts:13](https://github.com/paritytech/txwrapper/blob/4462996/src/util/constants.ts#L13)*
+*Defined in [src/util/constants.ts:13](https://github.com/paritytech/txwrapper/blob/32e6680/src/util/constants.ts#L13)*
 
 Latest extrinsic version.
 
@@ -26,7 +26,7 @@ ___
 
 • **KUSAMA_SS58_FORMAT**: *2* = 2
 
-*Defined in [src/util/constants.ts:4](https://github.com/paritytech/txwrapper/blob/4462996/src/util/constants.ts#L4)*
+*Defined in [src/util/constants.ts:4](https://github.com/paritytech/txwrapper/blob/32e6680/src/util/constants.ts#L4)*
 
 Prefix for SS58-encoded addresses on Kusama.
 
@@ -36,6 +36,6 @@ ___
 
 • **POLKADOT_SS58_FORMAT**: *0* = 0
 
-*Defined in [src/util/constants.ts:8](https://github.com/paritytech/txwrapper/blob/4462996/src/util/constants.ts#L8)*
+*Defined in [src/util/constants.ts:8](https://github.com/paritytech/txwrapper/blob/32e6680/src/util/constants.ts#L8)*
 
 Prefix for SS58-encoded addresses on Polkadot.

--- a/docs/modules/_util_registry_.md
+++ b/docs/modules/_util_registry_.md
@@ -14,7 +14,7 @@
 
 ▸ **getRegistry**(`specName`: "kusama", `specVersion`: number): *TypeRegistry*
 
-*Defined in [src/util/registry.ts:13](https://github.com/paritytech/txwrapper/blob/4462996/src/util/registry.ts#L13)*
+*Defined in [src/util/registry.ts:13](https://github.com/paritytech/txwrapper/blob/32e6680/src/util/registry.ts#L13)*
 
 Create a specific TypeRegistry for a current chain. The reason we have this
 is, depending on different runtime versions, we have different types (e.g.:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import * as methods from './methods';
+
 export * from './createSignedTx';
 export * from './createSigningPayload';
 export * from './decode/decode';
@@ -5,3 +7,5 @@ export * from './deriveAddress';
 export * from './getTxHash';
 export * from './importPrivateKey';
 export * from './methods';
+
+export { methods };


### PR DESCRIPTION
The docs say `import { methods } from '@substrate/txwrapper'`, but @axelchalon found out that `methods` was actually not exported, only its children (e.g. `staking`, `session`).

This PR exports `methods` too.