### PR TITLE
feat: Deprecate `validityPeriod`, use `eraPeriod` in blocks instead

### DIFF
--- a/docs/interfaces/_src_methods_balances_transfer_.balancestransferargs.md
+++ b/docs/interfaces/_src_methods_balances_transfer_.balancestransferargs.md
@@ -21,7 +21,7 @@
 
 • **dest**: *string*
 
-*Defined in [src/methods/balances/transfer.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/balances/transfer.ts#L13)*
+*Defined in [src/methods/balances/transfer.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/balances/transfer.ts#L13)*
 
 The recipient address, SS-58 encoded.
 
@@ -29,8 +29,8 @@ ___
 
 ###  value
 
-• **value**: *number*
+• **value**: *number | string*
 
-*Defined in [src/methods/balances/transfer.ts:17](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/balances/transfer.ts#L17)*
+*Defined in [src/methods/balances/transfer.ts:17](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/balances/transfer.ts#L17)*
 
 The amount to send.

--- a/docs/interfaces/_src_methods_democracy_activateproxy_.democracyactivateproxyargs.md
+++ b/docs/interfaces/_src_methods_democracy_activateproxy_.democracyactivateproxyargs.md
@@ -20,6 +20,6 @@
 
 • **proxy**: *string*
 
-*Defined in [src/methods/democracy/activateProxy.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/activateProxy.ts#L13)*
+*Defined in [src/methods/democracy/activateProxy.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/activateProxy.ts#L13)*
 
 Address to set as proxy, SS-58 encoded.

--- a/docs/interfaces/_src_methods_democracy_deactivateproxy_.democracydeactivateproxyargs.md
+++ b/docs/interfaces/_src_methods_democracy_deactivateproxy_.democracydeactivateproxyargs.md
@@ -20,6 +20,6 @@
 
 • **proxy**: *string*
 
-*Defined in [src/methods/democracy/deactivateProxy.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/deactivateProxy.ts#L13)*
+*Defined in [src/methods/democracy/deactivateProxy.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/deactivateProxy.ts#L13)*
 
 The address of the proxy to remove, SS-58 encoded.

--- a/docs/interfaces/_src_methods_democracy_openproxy_.democracyopenproxyargs.md
+++ b/docs/interfaces/_src_methods_democracy_openproxy_.democracyopenproxyargs.md
@@ -20,6 +20,6 @@
 
 • **target**: *string*
 
-*Defined in [src/methods/democracy/openProxy.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/openProxy.ts#L13)*
+*Defined in [src/methods/democracy/openProxy.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/openProxy.ts#L13)*
 
 The address of the proxy to remove, SS-58 encoded.

--- a/docs/interfaces/_src_methods_democracy_proxyvote_.democracyproxyvoteargs.md
+++ b/docs/interfaces/_src_methods_democracy_proxyvote_.democracyproxyvoteargs.md
@@ -21,7 +21,7 @@
 
 • **refIndex**: *number*
 
-*Defined in [src/methods/democracy/proxyVote.ts:14](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/proxyVote.ts#L14)*
+*Defined in [src/methods/democracy/proxyVote.ts:14](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/proxyVote.ts#L14)*
 
 ___
 
@@ -29,6 +29,6 @@ ___
 
 • **vote**: *[AccountVote](../modules/_src_methods_democracy_types_.md#accountvote)*
 
-*Defined in [src/methods/democracy/proxyVote.ts:18](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/proxyVote.ts#L18)*
+*Defined in [src/methods/democracy/proxyVote.ts:18](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/proxyVote.ts#L18)*
 
 Vote.

--- a/docs/interfaces/_src_methods_democracy_vote_.democracyvoteargs.md
+++ b/docs/interfaces/_src_methods_democracy_vote_.democracyvoteargs.md
@@ -21,7 +21,7 @@
 
 • **refIndex**: *number*
 
-*Defined in [src/methods/democracy/vote.ts:14](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/vote.ts#L14)*
+*Defined in [src/methods/democracy/vote.ts:14](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/vote.ts#L14)*
 
 ___
 
@@ -29,6 +29,6 @@ ___
 
 • **vote**: *[AccountVote](../modules/_src_methods_democracy_types_.md#accountvote)*
 
-*Defined in [src/methods/democracy/vote.ts:18](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/vote.ts#L18)*
+*Defined in [src/methods/democracy/vote.ts:18](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/vote.ts#L18)*
 
 Vote.

--- a/docs/interfaces/_src_methods_session_setkeys_.sessionsetkeysargs.md
+++ b/docs/interfaces/_src_methods_session_setkeys_.sessionsetkeysargs.md
@@ -21,7 +21,7 @@
 
 • **keys**: *string[]*
 
-*Defined in [src/methods/session/setKeys.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/session/setKeys.ts#L13)*
+*Defined in [src/methods/session/setKeys.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/session/setKeys.ts#L13)*
 
 The 5 keys to set.
 
@@ -31,6 +31,6 @@ ___
 
 • **proof**? : *undefined | string*
 
-*Defined in [src/methods/session/setKeys.ts:17](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/session/setKeys.ts#L17)*
+*Defined in [src/methods/session/setKeys.ts:17](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/session/setKeys.ts#L17)*
 
 Proof (unused for now).

--- a/docs/interfaces/_src_methods_staking_bond_.stakingbondargs.md
+++ b/docs/interfaces/_src_methods_staking_bond_.stakingbondargs.md
@@ -22,7 +22,7 @@
 
 • **controller**: *string*
 
-*Defined in [src/methods/staking/bond.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/bond.ts#L13)*
+*Defined in [src/methods/staking/bond.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/bond.ts#L13)*
 
 The SS-58 encoded address of the Controller account.
 
@@ -32,7 +32,7 @@ ___
 
 • **payee**: *string*
 
-*Defined in [src/methods/staking/bond.ts:21](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/bond.ts#L21)*
+*Defined in [src/methods/staking/bond.ts:21](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/bond.ts#L21)*
 
 The rewards destination. Can be "Stash", "Staked", or "Controller".
 
@@ -42,6 +42,6 @@ ___
 
 • **value**: *number*
 
-*Defined in [src/methods/staking/bond.ts:17](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/bond.ts#L17)*
+*Defined in [src/methods/staking/bond.ts:17](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/bond.ts#L17)*
 
 The number of tokens to bond.

--- a/docs/interfaces/_src_methods_staking_bondextra_.stakingbondextraargs.md
+++ b/docs/interfaces/_src_methods_staking_bondextra_.stakingbondextraargs.md
@@ -20,6 +20,6 @@
 
 • **maxAdditional**: *number*
 
-*Defined in [src/methods/staking/bondExtra.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/bondExtra.ts#L13)*
+*Defined in [src/methods/staking/bondExtra.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/bondExtra.ts#L13)*
 
 The maximum amount to bond.

--- a/docs/interfaces/_src_methods_staking_nominate_.stakingnominateargs.md
+++ b/docs/interfaces/_src_methods_staking_nominate_.stakingnominateargs.md
@@ -20,7 +20,7 @@
 
 • **targets**: *Array‹string›*
 
-*Defined in [src/methods/staking/nominate.ts:16](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/nominate.ts#L16)*
+*Defined in [src/methods/staking/nominate.ts:16](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/nominate.ts#L16)*
 
 The SS-58 encoded addresses of the targets you wish to nominate. A maximum of 16
 nominations are allowed.

--- a/docs/interfaces/_src_methods_staking_payoutnominator_.stakingpayoutnominatorargs.md
+++ b/docs/interfaces/_src_methods_staking_payoutnominator_.stakingpayoutnominatorargs.md
@@ -21,7 +21,7 @@
 
 • **era**: *number*
 
-*Defined in [src/methods/staking/payoutNominator.ts:15](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/payoutNominator.ts#L15)*
+*Defined in [src/methods/staking/payoutNominator.ts:15](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/payoutNominator.ts#L15)*
 
 May not be lower than one following the most recently paid era. If it is
 higher, then it indicates an instruction to skip the payout of all
@@ -33,7 +33,7 @@ ___
 
 • **validators**: *[string, number][]*
 
-*Defined in [src/methods/staking/payoutNominator.ts:22](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/payoutNominator.ts#L22)*
+*Defined in [src/methods/staking/payoutNominator.ts:22](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/payoutNominator.ts#L22)*
 
 List of all validators that `who` had exposure to during `era` alongside
 the index of the `who` in the clipped exposure of the validator. i.e. each

--- a/docs/interfaces/_src_methods_staking_payoutvalidator_.stakingpayoutvalidatorargs.md
+++ b/docs/interfaces/_src_methods_staking_payoutvalidator_.stakingpayoutvalidatorargs.md
@@ -20,7 +20,7 @@
 
 • **era**: *number*
 
-*Defined in [src/methods/staking/payoutValidator.ts:15](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/payoutValidator.ts#L15)*
+*Defined in [src/methods/staking/payoutValidator.ts:15](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/payoutValidator.ts#L15)*
 
 May not be lower than one following the most recently paid era. If it is
 higher, then it indicates an instruction to skip the payout of all

--- a/docs/interfaces/_src_methods_staking_setcontroller_.stakingsetcontrollerargs.md
+++ b/docs/interfaces/_src_methods_staking_setcontroller_.stakingsetcontrollerargs.md
@@ -20,6 +20,6 @@
 
 • **controller**: *string*
 
-*Defined in [src/methods/staking/setController.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/setController.ts#L13)*
+*Defined in [src/methods/staking/setController.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/setController.ts#L13)*
 
 The SS-58 encoded controller address.

--- a/docs/interfaces/_src_methods_staking_unbond_.stakingunbondargs.md
+++ b/docs/interfaces/_src_methods_staking_unbond_.stakingunbondargs.md
@@ -20,6 +20,6 @@
 
 • **value**: *number*
 
-*Defined in [src/methods/staking/unbond.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/unbond.ts#L13)*
+*Defined in [src/methods/staking/unbond.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/unbond.ts#L13)*
 
 The number of tokens to unbond.

--- a/docs/interfaces/_src_methods_staking_validate_.stakingvalidateargs.md
+++ b/docs/interfaces/_src_methods_staking_validate_.stakingvalidateargs.md
@@ -20,7 +20,7 @@
 
 • **prefs**: *object*
 
-*Defined in [src/methods/staking/validate.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/validate.ts#L13)*
+*Defined in [src/methods/staking/validate.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/validate.ts#L13)*
 
 Set the desired commission for the validator. Value is Perbill.
 

--- a/docs/interfaces/_src_methods_vesting_vestother_.vestingvestotherargs.md
+++ b/docs/interfaces/_src_methods_vesting_vestother_.vestingvestotherargs.md
@@ -20,7 +20,7 @@
 
 • **target**: *string*
 
-*Defined in [src/methods/vesting/vestOther.ts:14](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/vesting/vestOther.ts#L14)*
+*Defined in [src/methods/vesting/vestOther.ts:14](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/vesting/vestOther.ts#L14)*
 
 The account whose vested funds should be unlocked. Must have funds still
 locked under this module.

--- a/docs/interfaces/_src_util_metadata_.chainproperties.md
+++ b/docs/interfaces/_src_util_metadata_.chainproperties.md
@@ -22,7 +22,7 @@ JSON object of ChainProperties codec from `@polkadot/api`.
 
 • **ss58Format**: *number*
 
-*Defined in [src/util/metadata.ts:16](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/metadata.ts#L16)*
+*Defined in [src/util/metadata.ts:16](https://github.com/paritytech/txwrapper/blob/9698841/src/util/metadata.ts#L16)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **tokenDecimals**: *number*
 
-*Defined in [src/util/metadata.ts:17](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/metadata.ts#L17)*
+*Defined in [src/util/metadata.ts:17](https://github.com/paritytech/txwrapper/blob/9698841/src/util/metadata.ts#L17)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 • **tokenSymbol**: *string*
 
-*Defined in [src/util/metadata.ts:18](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/metadata.ts#L18)*
+*Defined in [src/util/metadata.ts:18](https://github.com/paritytech/txwrapper/blob/9698841/src/util/metadata.ts#L18)*

--- a/docs/interfaces/_src_util_options_.options.md
+++ b/docs/interfaces/_src_util_options_.options.md
@@ -22,7 +22,7 @@ Runtime-specific options for encoding and decoding transactions.
 
 • **metadata**: *string*
 
-*Defined in [src/util/options.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/options.ts#L13)*
+*Defined in [src/util/options.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/util/options.ts#L13)*
 
 The metadata of the runtime.
 
@@ -32,7 +32,7 @@ ___
 
 • **registry**? : *TypeRegistry*
 
-*Defined in [src/util/options.ts:17](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/options.ts#L17)*
+*Defined in [src/util/options.ts:17](https://github.com/paritytech/txwrapper/blob/9698841/src/util/options.ts#L17)*
 
 The type registry of the runtime. Defaults to Kusama's type registry
 
@@ -42,7 +42,7 @@ ___
 
 • **ss58Format**? : *undefined | number*
 
-*Defined in [src/util/options.ts:23](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/options.ts#L23)*
+*Defined in [src/util/options.ts:23](https://github.com/paritytech/txwrapper/blob/9698841/src/util/options.ts#L23)*
 
 **`deprecated`** Please use `registry.setChainProperties()` instead, and pass the correct SS58 prefix in the chain properties.
 

--- a/docs/interfaces/_src_util_types_.basetxinfo.md
+++ b/docs/interfaces/_src_util_types_.basetxinfo.md
@@ -15,6 +15,7 @@ JSON format for information that is common to all transactions.
 * [address](_src_util_types_.basetxinfo.md#address)
 * [blockHash](_src_util_types_.basetxinfo.md#blockhash)
 * [blockNumber](_src_util_types_.basetxinfo.md#blocknumber)
+* [eraPeriod](_src_util_types_.basetxinfo.md#optional-eraperiod)
 * [genesisHash](_src_util_types_.basetxinfo.md#genesishash)
 * [metadataRpc](_src_util_types_.basetxinfo.md#metadatarpc)
 * [nonce](_src_util_types_.basetxinfo.md#nonce)
@@ -28,7 +29,7 @@ JSON format for information that is common to all transactions.
 
 • **address**: *string*
 
-*Defined in [src/util/types.ts:21](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/types.ts#L21)*
+*Defined in [src/util/types.ts:21](https://github.com/paritytech/txwrapper/blob/9698841/src/util/types.ts#L21)*
 
 The ss-58 encoded address of the sending account.
 
@@ -38,7 +39,7 @@ ___
 
 • **blockHash**: *string*
 
-*Defined in [src/util/types.ts:25](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/types.ts#L25)*
+*Defined in [src/util/types.ts:25](https://github.com/paritytech/txwrapper/blob/9698841/src/util/types.ts#L25)*
 
 The checkpoint hash of the block, in hex.
 
@@ -48,9 +49,22 @@ ___
 
 • **blockNumber**: *number*
 
-*Defined in [src/util/types.ts:29](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/types.ts#L29)*
+*Defined in [src/util/types.ts:29](https://github.com/paritytech/txwrapper/blob/9698841/src/util/types.ts#L29)*
 
 The checkpoint block number (u32), in hex.
+
+___
+
+### `Optional` eraPeriod
+
+• **eraPeriod**? : *undefined | number*
+
+*Defined in [src/util/types.ts:36](https://github.com/paritytech/txwrapper/blob/9698841/src/util/types.ts#L36)*
+
+Describe the longevity of a transaction. It represents the validity from
+the `blockHash` field, in number of blocks. Defaults to 64 blocks.
+
+**`default`** 64
 
 ___
 
@@ -58,7 +72,7 @@ ___
 
 • **genesisHash**: *string*
 
-*Defined in [src/util/types.ts:33](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/types.ts#L33)*
+*Defined in [src/util/types.ts:40](https://github.com/paritytech/txwrapper/blob/9698841/src/util/types.ts#L40)*
 
 The genesis hash of the chain, in hex.
 
@@ -68,7 +82,7 @@ ___
 
 • **metadataRpc**: *string*
 
-*Defined in [src/util/types.ts:38](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/types.ts#L38)*
+*Defined in [src/util/types.ts:45](https://github.com/paritytech/txwrapper/blob/9698841/src/util/types.ts#L45)*
 
 The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC
 call `state_getMetadata`.
@@ -79,7 +93,7 @@ ___
 
 • **nonce**: *number*
 
-*Defined in [src/util/types.ts:42](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/types.ts#L42)*
+*Defined in [src/util/types.ts:49](https://github.com/paritytech/txwrapper/blob/9698841/src/util/types.ts#L49)*
 
 The nonce for this transaction.
 
@@ -89,7 +103,7 @@ ___
 
 • **specVersion**: *number*
 
-*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/types.ts#L46)*
+*Defined in [src/util/types.ts:53](https://github.com/paritytech/txwrapper/blob/9698841/src/util/types.ts#L53)*
 
 The current spec version for the runtime.
 
@@ -99,7 +113,7 @@ ___
 
 • **tip**? : *undefined | number*
 
-*Defined in [src/util/types.ts:52](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/types.ts#L52)*
+*Defined in [src/util/types.ts:59](https://github.com/paritytech/txwrapper/blob/9698841/src/util/types.ts#L59)*
 
 The tip for this transaction, in hex.
 
@@ -111,9 +125,11 @@ ___
 
 • **validityPeriod**? : *undefined | number*
 
-*Defined in [src/util/types.ts:59](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/types.ts#L59)*
+*Defined in [src/util/types.ts:67](https://github.com/paritytech/txwrapper/blob/9698841/src/util/types.ts#L67)*
 
 The amount of time (in second) the transaction is valid for. Will be
 translated into a mortal era. Defaults to 5 minutes.
+
+**`deprecated`** Please use `eraPeriod` instead.
 
 **`default`** 300

--- a/docs/interfaces/_src_util_types_.unsignedtransaction.md
+++ b/docs/interfaces/_src_util_types_.unsignedtransaction.md
@@ -92,7 +92,7 @@ ___
 
 • **metadataRpc**: *string*
 
-*Defined in [src/util/types.ts:11](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/types.ts#L11)*
+*Defined in [src/util/types.ts:11](https://github.com/paritytech/txwrapper/blob/9698841/src/util/types.ts#L11)*
 
 The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC
 call `state_getMetadata`.

--- a/docs/modules/_src_createsignedtx_.md
+++ b/docs/modules/_src_createsignedtx_.md
@@ -14,7 +14,7 @@
 
 ▸ **createSignedTx**(`unsigned`: [UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md), `signature`: string, `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *string*
 
-*Defined in [src/createSignedTx.ts:17](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/createSignedTx.ts#L17)*
+*Defined in [src/createSignedTx.ts:17](https://github.com/paritytech/txwrapper/blob/9698841/src/createSignedTx.ts#L17)*
 
 Serialize a signed transaction in a format that can be submitted over the
 Node RPC Interface from the signing payload and signature produced by the

--- a/docs/modules/_src_createsigningpayload_.md
+++ b/docs/modules/_src_createsigningpayload_.md
@@ -14,7 +14,7 @@
 
 ▸ **createSigningPayload**(`unsigned`: [UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *string*
 
-*Defined in [src/createSigningPayload.ts:9](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/createSigningPayload.ts#L9)*
+*Defined in [src/createSigningPayload.ts:9](https://github.com/paritytech/txwrapper/blob/9698841/src/createSigningPayload.ts#L9)*
 
 Construct the signing payload from an unsigned transaction and export it to
 a remote signer (this is often called "detached signing").

--- a/docs/modules/_src_decode_decode_.md
+++ b/docs/modules/_src_decode_decode_.md
@@ -14,7 +14,7 @@
 
 ▸ **decode**(`unsignedTx`: [UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md), `options`: [Options](../interfaces/_src_util_options_.options.md)): *DecodedUnsignedTx*
 
-*Defined in [src/decode/decode.ts:15](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/decode/decode.ts#L15)*
+*Defined in [src/decode/decode.ts:15](https://github.com/paritytech/txwrapper/blob/9698841/src/decode/decode.ts#L15)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 
@@ -29,7 +29,7 @@ Name | Type | Description |
 
 ▸ **decode**(`unsignedTx`: [UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md), `metadataRpc`: string, `ss58Format?`: undefined | number): *DecodedUnsignedTx*
 
-*Defined in [src/decode/decode.ts:29](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/decode/decode.ts#L29)*
+*Defined in [src/decode/decode.ts:29](https://github.com/paritytech/txwrapper/blob/9698841/src/decode/decode.ts#L29)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 
@@ -47,7 +47,7 @@ Name | Type | Description |
 
 ▸ **decode**(`signedTx`: string, `options`: [Options](../interfaces/_src_util_options_.options.md)): *DecodedSignedTx*
 
-*Defined in [src/decode/decode.ts:41](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/decode/decode.ts#L41)*
+*Defined in [src/decode/decode.ts:41](https://github.com/paritytech/txwrapper/blob/9698841/src/decode/decode.ts#L41)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 
@@ -62,7 +62,7 @@ Name | Type | Description |
 
 ▸ **decode**(`signedTx`: string, `metadataRpc`: string, `ss58Format?`: undefined | number): *DecodedSignedTx*
 
-*Defined in [src/decode/decode.ts:52](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/decode/decode.ts#L52)*
+*Defined in [src/decode/decode.ts:52](https://github.com/paritytech/txwrapper/blob/9698841/src/decode/decode.ts#L52)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 
@@ -80,7 +80,7 @@ Name | Type | Description |
 
 ▸ **decode**(`signingPayload`: string, `options`: [Options](../interfaces/_src_util_options_.options.md)): *DecodedSigningPayload*
 
-*Defined in [src/decode/decode.ts:64](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/decode/decode.ts#L64)*
+*Defined in [src/decode/decode.ts:64](https://github.com/paritytech/txwrapper/blob/9698841/src/decode/decode.ts#L64)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 
@@ -95,7 +95,7 @@ Name | Type | Description |
 
 ▸ **decode**(`signingPayload`: string, `metadataRpc`: string, `ss58Format?`: undefined | number): *DecodedSigningPayload*
 
-*Defined in [src/decode/decode.ts:78](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/decode/decode.ts#L78)*
+*Defined in [src/decode/decode.ts:78](https://github.com/paritytech/txwrapper/blob/9698841/src/decode/decode.ts#L78)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 

--- a/docs/modules/_src_deriveaddress_.md
+++ b/docs/modules/_src_deriveaddress_.md
@@ -14,7 +14,7 @@
 
 ▸ **deriveAddress**(`publicKey`: string | Uint8Array, `ss58Format`: number): *string*
 
-*Defined in [src/deriveAddress.ts:11](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/deriveAddress.ts#L11)*
+*Defined in [src/deriveAddress.ts:11](https://github.com/paritytech/txwrapper/blob/9698841/src/deriveAddress.ts#L11)*
 
 Derive an address from a cryptographic public key offline.
 

--- a/docs/modules/_src_gettxhash_.md
+++ b/docs/modules/_src_gettxhash_.md
@@ -14,7 +14,7 @@
 
 ▸ **getTxHash**(`signedTx`: string): *string*
 
-*Defined in [src/getTxHash.ts:8](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/getTxHash.ts#L8)*
+*Defined in [src/getTxHash.ts:8](https://github.com/paritytech/txwrapper/blob/9698841/src/getTxHash.ts#L8)*
 
 Derive the tx hash of a signed transaction offline.
 

--- a/docs/modules/_src_importprivatekey_.md
+++ b/docs/modules/_src_importprivatekey_.md
@@ -18,7 +18,7 @@
 
 Ƭ **KeyringPair**: *KeyringPairBase*
 
-*Defined in [src/importPrivateKey.ts:10](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/importPrivateKey.ts#L10)*
+*Defined in [src/importPrivateKey.ts:10](https://github.com/paritytech/txwrapper/blob/9698841/src/importPrivateKey.ts#L10)*
 
 A keyring pair
 
@@ -28,7 +28,7 @@ A keyring pair
 
 ▸ **importPrivateKey**(`privateKey`: string | Uint8Array, `ss58Format`: number): *KeyringPair*
 
-*Defined in [src/importPrivateKey.ts:18](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/importPrivateKey.ts#L18)*
+*Defined in [src/importPrivateKey.ts:18](https://github.com/paritytech/txwrapper/blob/9698841/src/importPrivateKey.ts#L18)*
 
 Import a private key and create a KeyringPair.
 

--- a/docs/modules/_src_methods_balances_transfer_.md
+++ b/docs/modules/_src_methods_balances_transfer_.md
@@ -18,7 +18,7 @@
 
 ▸ **transfer**(`args`: [BalancesTransferArgs](../interfaces/_src_methods_balances_transfer_.balancestransferargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/balances/transfer.ts:25](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/balances/transfer.ts#L25)*
+*Defined in [src/methods/balances/transfer.ts:25](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/balances/transfer.ts#L25)*
 
 Construct a balance transfer transaction offline.
 

--- a/docs/modules/_src_methods_balances_transferkeepalive_.md
+++ b/docs/modules/_src_methods_balances_transferkeepalive_.md
@@ -18,7 +18,7 @@
 
 Ƭ **BalancesTransferKeepAliveArgs**: *[BalancesTransferArgs](../interfaces/_src_methods_balances_transfer_.balancestransferargs.md)*
 
-*Defined in [src/methods/balances/transferKeepAlive.ts:9](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/balances/transferKeepAlive.ts#L9)*
+*Defined in [src/methods/balances/transferKeepAlive.ts:9](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/balances/transferKeepAlive.ts#L9)*
 
 ## Functions
 
@@ -26,7 +26,7 @@
 
 ▸ **transferKeepAlive**(`args`: [BalancesTransferKeepAliveArgs](_src_methods_balances_transferkeepalive_.md#balancestransferkeepaliveargs), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/balances/transferKeepAlive.ts:16](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/balances/transferKeepAlive.ts#L16)*
+*Defined in [src/methods/balances/transferKeepAlive.ts:16](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/balances/transferKeepAlive.ts#L16)*
 
 Construct a balance transfer transaction offline.
 

--- a/docs/modules/_src_methods_democracy_activateproxy_.md
+++ b/docs/modules/_src_methods_democracy_activateproxy_.md
@@ -18,7 +18,7 @@
 
 ▸ **activateProxy**(`args`: [DemocracyActivateProxyArgs](../interfaces/_src_methods_democracy_activateproxy_.democracyactivateproxyargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/activateProxy.ts:21](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/activateProxy.ts#L21)*
+*Defined in [src/methods/democracy/activateProxy.ts:21](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/activateProxy.ts#L21)*
 
 Specify a proxy that is already open to us. Called by the stash.
 

--- a/docs/modules/_src_methods_democracy_closeproxy_.md
+++ b/docs/modules/_src_methods_democracy_closeproxy_.md
@@ -14,7 +14,7 @@
 
 ▸ **closeProxy**(`args`: object, `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/closeProxy.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/closeProxy.ts#L13)*
+*Defined in [src/methods/democracy/closeProxy.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/closeProxy.ts#L13)*
 
 Clear the proxy. Called by the proxy.
 

--- a/docs/modules/_src_methods_democracy_deactivateproxy_.md
+++ b/docs/modules/_src_methods_democracy_deactivateproxy_.md
@@ -18,7 +18,7 @@
 
 ▸ **deactivateProxy**(`args`: [DemocracyDeactivateProxyArgs](../interfaces/_src_methods_democracy_deactivateproxy_.democracydeactivateproxyargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/deactivateProxy.ts:22](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/deactivateProxy.ts#L22)*
+*Defined in [src/methods/democracy/deactivateProxy.ts:22](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/deactivateProxy.ts#L22)*
 
 Deactivate the proxy, but leave open to this account. Called by the stash.
 The proxy must already be active.

--- a/docs/modules/_src_methods_democracy_openproxy_.md
+++ b/docs/modules/_src_methods_democracy_openproxy_.md
@@ -18,7 +18,7 @@
 
 ▸ **openProxy**(`args`: [DemocracyOpenProxyArgs](../interfaces/_src_methods_democracy_openproxy_.democracyopenproxyargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/openProxy.ts:21](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/openProxy.ts#L21)*
+*Defined in [src/methods/democracy/openProxy.ts:21](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/openProxy.ts#L21)*
 
 Become a proxy. This must be called prior to a later `activateProxy`.
 

--- a/docs/modules/_src_methods_democracy_proxyvote_.md
+++ b/docs/modules/_src_methods_democracy_proxyvote_.md
@@ -18,7 +18,7 @@
 
 ▸ **proxyVote**(`args`: [DemocracyProxyVoteArgs](../interfaces/_src_methods_democracy_proxyvote_.democracyproxyvoteargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/proxyVote.ts:26](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/proxyVote.ts#L26)*
+*Defined in [src/methods/democracy/proxyVote.ts:26](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/proxyVote.ts#L26)*
 
 Vote in a referendum on behalf of a stash.
 

--- a/docs/modules/_src_methods_democracy_types_.md
+++ b/docs/modules/_src_methods_democracy_types_.md
@@ -15,7 +15,7 @@
 
 Ƭ **AccountVote**: *object | object*
 
-*Defined in [src/methods/democracy/types.ts:26](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/types.ts#L26)*
+*Defined in [src/methods/democracy/types.ts:26](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/types.ts#L26)*
 
 A vote in a referendum. Can be one of:
 - Standard: A standard vote, one-way (approve or reject) with a given amount
@@ -29,7 +29,7 @@ ___
 
 Ƭ **Vote**: *object*
 
-*Defined in [src/methods/democracy/types.ts:7](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/types.ts#L7)*
+*Defined in [src/methods/democracy/types.ts:7](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/types.ts#L7)*
 
 A vote in a referendum
 

--- a/docs/modules/_src_methods_democracy_vote_.md
+++ b/docs/modules/_src_methods_democracy_vote_.md
@@ -18,7 +18,7 @@
 
 ▸ **vote**(`args`: [DemocracyVoteArgs](../interfaces/_src_methods_democracy_vote_.democracyvoteargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/vote.ts:26](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/democracy/vote.ts#L26)*
+*Defined in [src/methods/democracy/vote.ts:26](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/democracy/vote.ts#L26)*
 
 Vote in a referendum.
 

--- a/docs/modules/_src_methods_session_setkeys_.md
+++ b/docs/modules/_src_methods_session_setkeys_.md
@@ -18,7 +18,7 @@
 
 ▸ **setKeys**(`args`: [SessionSetKeysArgs](../interfaces/_src_methods_session_setkeys_.sessionsetkeysargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/session/setKeys.ts:25](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/session/setKeys.ts#L25)*
+*Defined in [src/methods/session/setKeys.ts:25](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/session/setKeys.ts#L25)*
 
 Sets the session key(s) of the function caller to `key`.
 

--- a/docs/modules/_src_methods_staking_bond_.md
+++ b/docs/modules/_src_methods_staking_bond_.md
@@ -18,7 +18,7 @@
 
 ▸ **bond**(`args`: [StakingBondArgs](../interfaces/_src_methods_staking_bond_.stakingbondargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/bond.ts:29](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/bond.ts#L29)*
+*Defined in [src/methods/staking/bond.ts:29](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/bond.ts#L29)*
 
 Construct a transaction to bond funds and create a Stash account.
 

--- a/docs/modules/_src_methods_staking_bondextra_.md
+++ b/docs/modules/_src_methods_staking_bondextra_.md
@@ -18,7 +18,7 @@
 
 ▸ **bondExtra**(`args`: [StakingBondExtraArgs](../interfaces/_src_methods_staking_bondextra_.stakingbondextraargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/bondExtra.ts:22](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/bondExtra.ts#L22)*
+*Defined in [src/methods/staking/bondExtra.ts:22](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/bondExtra.ts#L22)*
 
 Add some extra amount that have appeared in the stash `free_balance` into
 the balance up for staking.

--- a/docs/modules/_src_methods_staking_chill_.md
+++ b/docs/modules/_src_methods_staking_chill_.md
@@ -14,7 +14,7 @@
 
 ▸ **chill**(`args`: object, `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/chill.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/chill.ts#L13)*
+*Defined in [src/methods/staking/chill.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/chill.ts#L13)*
 
 Declare the desire to cease validating or nominating. Does not unbond funds.
 

--- a/docs/modules/_src_methods_staking_nominate_.md
+++ b/docs/modules/_src_methods_staking_nominate_.md
@@ -18,7 +18,7 @@
 
 ▸ **nominate**(`args`: [StakingNominateArgs](../interfaces/_src_methods_staking_nominate_.stakingnominateargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/nominate.ts:24](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/nominate.ts#L24)*
+*Defined in [src/methods/staking/nominate.ts:24](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/nominate.ts#L24)*
 
 Construct a transaction to nominate. This must be called by the _Controller_ account.
 

--- a/docs/modules/_src_methods_staking_payoutnominator_.md
+++ b/docs/modules/_src_methods_staking_payoutnominator_.md
@@ -18,7 +18,7 @@
 
 ▸ **payoutNominator**(`args`: [StakingPayoutNominatorArgs](../interfaces/_src_methods_staking_payoutnominator_.stakingpayoutnominatorargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/payoutNominator.ts:33](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/payoutNominator.ts#L33)*
+*Defined in [src/methods/staking/payoutNominator.ts:33](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/payoutNominator.ts#L33)*
 
 Make one nominator's payout for one era.
 WARNING: once an era is payed for a validator such validator can't claim the

--- a/docs/modules/_src_methods_staking_payoutvalidator_.md
+++ b/docs/modules/_src_methods_staking_payoutvalidator_.md
@@ -18,7 +18,7 @@
 
 ▸ **payoutValidator**(`args`: [StakingPayoutValidatorArgs](../interfaces/_src_methods_staking_payoutvalidator_.stakingpayoutvalidatorargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/payoutValidator.ts:26](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/payoutValidator.ts#L26)*
+*Defined in [src/methods/staking/payoutValidator.ts:26](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/payoutValidator.ts#L26)*
 
 Make one validator's payout for one era.
 WARNING: once an era is payed for a validator such validator can't claim the

--- a/docs/modules/_src_methods_staking_setcontroller_.md
+++ b/docs/modules/_src_methods_staking_setcontroller_.md
@@ -18,7 +18,7 @@
 
 ▸ **setController**(`args`: [StakingSetControllerArgs](../interfaces/_src_methods_staking_setcontroller_.stakingsetcontrollerargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/setController.ts:22](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/setController.ts#L22)*
+*Defined in [src/methods/staking/setController.ts:22](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/setController.ts#L22)*
 
 (Re-)set the controller of a stash. Effects will be felt at the beginning of
 the next era.

--- a/docs/modules/_src_methods_staking_unbond_.md
+++ b/docs/modules/_src_methods_staking_unbond_.md
@@ -18,7 +18,7 @@
 
 ▸ **unbond**(`args`: [StakingUnbondArgs](../interfaces/_src_methods_staking_unbond_.stakingunbondargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/unbond.ts:22](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/unbond.ts#L22)*
+*Defined in [src/methods/staking/unbond.ts:22](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/unbond.ts#L22)*
 
 Construct a transaction to unbond funds from a Stash account. This must be called
 by the _Controller_ account.

--- a/docs/modules/_src_methods_staking_validate_.md
+++ b/docs/modules/_src_methods_staking_validate_.md
@@ -18,7 +18,7 @@
 
 ▸ **validate**(`args`: [StakingValidateArgs](../interfaces/_src_methods_staking_validate_.stakingvalidateargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/validate.ts:23](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/validate.ts#L23)*
+*Defined in [src/methods/staking/validate.ts:23](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/validate.ts#L23)*
 
 Declare the desire to validate for the origin controller.
 

--- a/docs/modules/_src_methods_staking_withdrawunbonded_.md
+++ b/docs/modules/_src_methods_staking_withdrawunbonded_.md
@@ -14,7 +14,7 @@
 
 ▸ **withdrawUnbonded**(`args`: object, `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/withdrawUnbonded.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/staking/withdrawUnbonded.ts#L13)*
+*Defined in [src/methods/staking/withdrawUnbonded.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/staking/withdrawUnbonded.ts#L13)*
 
 Remove any unlocked chunks from the `unlocking` queue from our management.
 

--- a/docs/modules/_src_methods_vesting_vest_.md
+++ b/docs/modules/_src_methods_vesting_vest_.md
@@ -14,7 +14,7 @@
 
 ▸ **vest**(`args`: object, `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/vesting/vest.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/vesting/vest.ts#L13)*
+*Defined in [src/methods/vesting/vest.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/vesting/vest.ts#L13)*
 
 Unlock any vested funds of the sender account.
 

--- a/docs/modules/_src_methods_vesting_vestother_.md
+++ b/docs/modules/_src_methods_vesting_vestother_.md
@@ -18,7 +18,7 @@
 
 ▸ **vestOther**(`args`: [VestingVestOtherArgs](../interfaces/_src_methods_vesting_vestother_.vestingvestotherargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options?`: Partial‹[Options](../interfaces/_src_util_options_.options.md)›): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/vesting/vestOther.ts:22](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/methods/vesting/vestOther.ts#L22)*
+*Defined in [src/methods/vesting/vestOther.ts:22](https://github.com/paritytech/txwrapper/blob/9698841/src/methods/vesting/vestOther.ts#L22)*
 
 Unlock any vested funds of a `target` account.
 

--- a/docs/modules/_src_util_constants_.md
+++ b/docs/modules/_src_util_constants_.md
@@ -17,7 +17,7 @@
 
 • **EXTRINSIC_VERSION**: *4* = 4
 
-*Defined in [src/util/constants.ts:18](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/constants.ts#L18)*
+*Defined in [src/util/constants.ts:18](https://github.com/paritytech/txwrapper/blob/9698841/src/util/constants.ts#L18)*
 
 Latest extrinsic version.
 
@@ -27,7 +27,7 @@ ___
 
 • **KUSAMA_SS58_FORMAT**: *2* = 2
 
-*Defined in [src/util/constants.ts:4](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/constants.ts#L4)*
+*Defined in [src/util/constants.ts:4](https://github.com/paritytech/txwrapper/blob/9698841/src/util/constants.ts#L4)*
 
 Prefix for SS58-encoded addresses on Kusama.
 
@@ -37,7 +37,7 @@ ___
 
 • **POLKADOT_SS58_FORMAT**: *0* = 0
 
-*Defined in [src/util/constants.ts:8](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/constants.ts#L8)*
+*Defined in [src/util/constants.ts:8](https://github.com/paritytech/txwrapper/blob/9698841/src/util/constants.ts#L8)*
 
 Prefix for SS58-encoded addresses on Polkadot.
 
@@ -47,7 +47,7 @@ ___
 
 • **WESTEND_SS58_FORMAT**: *42* = 42
 
-*Defined in [src/util/constants.ts:13](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/constants.ts#L13)*
+*Defined in [src/util/constants.ts:13](https://github.com/paritytech/txwrapper/blob/9698841/src/util/constants.ts#L13)*
 
 Prefix for SS58-encoded addresses on Westend.
 Also the default for Substrate-based chains.

--- a/docs/modules/_src_util_metadata_.md
+++ b/docs/modules/_src_util_metadata_.md
@@ -18,7 +18,7 @@
 
 ▸ **getRegistry**(`chainName`: "Kusama" | "Polkadot" | "Westend", `specName`: "kusama" | "polkadot" | "westend", `specVersion`: number): *TypeRegistry*
 
-*Defined in [src/util/metadata.ts:56](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/metadata.ts#L56)*
+*Defined in [src/util/metadata.ts:56](https://github.com/paritytech/txwrapper/blob/9698841/src/util/metadata.ts#L56)*
 
 Given a chain name and a spec version, return the corresponding type
 registry.

--- a/docs/modules/_src_util_options_.md
+++ b/docs/modules/_src_util_options_.md
@@ -18,7 +18,7 @@
 
 ▸ **sanitizeOptions**(`metadataOrOptions`: string | [Options](../interfaces/_src_util_options_.options.md), `ss58Format`: number): *Required‹[Options](../interfaces/_src_util_options_.options.md)›*
 
-*Defined in [src/util/options.ts:34](https://github.com/paritytech/txwrapper/blob/d1bfb8b/src/util/options.ts#L34)*
+*Defined in [src/util/options.ts:34](https://github.com/paritytech/txwrapper/blob/9698841/src/util/options.ts#L34)*
 
 Sanitize the options that the user pass in. In particular, the second
 argument can either be a string (the metadata) or an Options object. Also

--- a/examples/kusama.ts
+++ b/examples/kusama.ts
@@ -62,12 +62,12 @@ async function main(): Promise<void> {
       blockNumber: registry
         .createType('BlockNumber', block.header.number)
         .toNumber(),
+      eraPeriod: 50,
       genesisHash,
       metadataRpc,
       nonce: 1, // Assuming this is Alice's first tx on the chain
       specVersion,
       tip: 0,
-      validityPeriod: 240,
     },
     {
       metadata: metadataRpc,

--- a/examples/kusama.ts
+++ b/examples/kusama.ts
@@ -62,7 +62,7 @@ async function main(): Promise<void> {
       blockNumber: registry
         .createType('BlockNumber', block.header.number)
         .toNumber(),
-      eraPeriod: 50,
+      eraPeriod: 64,
       genesisHash,
       metadataRpc,
       nonce: 1, // Assuming this is Alice's first tx on the chain

--- a/examples/polkadot.ts
+++ b/examples/polkadot.ts
@@ -62,12 +62,12 @@ async function main(): Promise<void> {
       blockNumber: registry
         .createType('BlockNumber', block.header.number)
         .toNumber(),
+      eraPeriod: 50,
       genesisHash,
       metadataRpc,
       nonce: 0, // Assuming this is Alice's first tx on the chain
       specVersion,
       tip: 0,
-      validityPeriod: 240,
     },
     {
       metadata: metadataRpc,

--- a/examples/polkadot.ts
+++ b/examples/polkadot.ts
@@ -62,7 +62,7 @@ async function main(): Promise<void> {
       blockNumber: registry
         .createType('BlockNumber', block.header.number)
         .toNumber(),
-      eraPeriod: 50,
+      eraPeriod: 64,
       genesisHash,
       metadataRpc,
       nonce: 0, // Assuming this is Alice's first tx on the chain

--- a/examples/substrateMaster.ts
+++ b/examples/substrateMaster.ts
@@ -68,12 +68,12 @@ async function main(): Promise<void> {
       blockNumber: registry
         .createType('BlockNumber', block.header.number)
         .toNumber(),
+      eraPeriod: 50,
       genesisHash,
       metadataRpc,
       nonce: 1, // Assuming this is Alice's first tx on the chain
       specVersion,
       tip: 0,
-      validityPeriod: 240,
     },
     {
       metadata: metadataRpc,

--- a/examples/substrateMaster.ts
+++ b/examples/substrateMaster.ts
@@ -68,7 +68,7 @@ async function main(): Promise<void> {
       blockNumber: registry
         .createType('BlockNumber', block.header.number)
         .toNumber(),
-      eraPeriod: 50,
+      eraPeriod: 64,
       genesisHash,
       metadataRpc,
       nonce: 1, // Assuming this is Alice's first tx on the chain

--- a/src/decode/decodeSignedTx.spec.ts
+++ b/src/decode/decodeSignedTx.spec.ts
@@ -20,9 +20,10 @@ export function decodeBaseTxInfo(txInfo: DecodedSignedTx): void {
   (['address', 'metadataRpc', 'nonce', 'tip'] as const).forEach((key) =>
     expect(txInfo[key]).toBe(TEST_BASE_TX_INFO[key])
   );
-  expect(txInfo.validityPeriod).toBeGreaterThanOrEqual(
-    TEST_BASE_TX_INFO.validityPeriod
-  );
+
+  // The actual period is the smallest power of 2 greater than the input
+  // period.
+  expect(txInfo.eraPeriod).toBeGreaterThanOrEqual(TEST_BASE_TX_INFO.eraPeriod);
 }
 
 /**

--- a/src/decode/decodeSignedTx.ts
+++ b/src/decode/decodeSignedTx.ts
@@ -5,7 +5,6 @@
 import { hexToU8a } from '@polkadot/util';
 
 import {
-  BLOCKTIME,
   createMetadata,
   Options,
   sanitizeOptions,
@@ -64,10 +63,10 @@ export function decodeSignedTx(
 
   return {
     address: tx.signer.toString(),
+    eraPeriod: tx.era.asMortalEra.period.toNumber(),
     metadataRpc: metadata,
     method,
     nonce: tx.nonce.toNumber(),
     tip: tx.tip.toNumber(),
-    validityPeriod: tx.era.asMortalEra.period.toNumber() * BLOCKTIME,
   };
 }

--- a/src/decode/decodeSigningPayload.ts
+++ b/src/decode/decodeSigningPayload.ts
@@ -3,7 +3,6 @@
  */ /** */
 
 import {
-  BLOCKTIME,
   createMetadata,
   EXTRINSIC_VERSION,
   Options,
@@ -68,12 +67,12 @@ export function decodeSigningPayload(
 
   return {
     blockHash: payload.blockHash.toHex(),
+    eraPeriod: payload.era.asMortalEra.period.toNumber(),
     genesisHash: payload.genesisHash.toHex(),
     metadataRpc: metadata,
     method,
     nonce: payload.nonce.toNumber(),
     specVersion: payload.specVersion.toNumber(),
     tip: payload.tip.toNumber(),
-    validityPeriod: payload.era.asMortalEra.period.toNumber() * BLOCKTIME,
   };
 }

--- a/src/decode/decodeUnsignedTx.spec.ts
+++ b/src/decode/decodeUnsignedTx.spec.ts
@@ -28,9 +28,9 @@ export function decodeBaseTxInfo(txInfo: TxInfo): void {
     expect(txInfo[key]).toBe(TEST_BASE_TX_INFO[key])
   );
 
-  expect(txInfo.validityPeriod).toBeGreaterThanOrEqual(
-    TEST_BASE_TX_INFO.validityPeriod
-  );
+  // The actual period is the smallest power of 2 greater than the input
+  // period.
+  expect(txInfo.eraPeriod).toBeGreaterThanOrEqual(TEST_BASE_TX_INFO.eraPeriod);
 }
 
 /**

--- a/src/decode/decodeUnsignedTx.ts
+++ b/src/decode/decodeUnsignedTx.ts
@@ -3,7 +3,6 @@
  */ /** */
 
 import {
-  BLOCKTIME,
   createMetadata,
   Options,
   sanitizeOptions,
@@ -61,14 +60,12 @@ export function decodeUnsignedTx(
     blockNumber: registry
       .createType('BlockNumber', unsigned.blockNumber)
       .toNumber(),
+    eraPeriod: registry.createType('MortalEra', unsigned.era).period.toNumber(),
     genesisHash: unsigned.genesisHash,
     metadataRpc: metadata,
     method,
     nonce: registry.createType('Compact<Index>', unsigned.nonce).toNumber(),
     specVersion: registry.createType('u32', unsigned.specVersion).toNumber(),
     tip: registry.createType('Compact<Balance>', unsigned.tip).toNumber(),
-    validityPeriod:
-      registry.createType('MortalEra', unsigned.era).period.toNumber() *
-      BLOCKTIME,
   };
 }

--- a/src/methods/balances/transfer.spec.ts
+++ b/src/methods/balances/transfer.spec.ts
@@ -17,4 +17,19 @@ describe('balances::transfer', () => {
       '0x060096074594cccf1cd185fa8a72ceaeefd86648f8d45514f3ce33c31bdd07e4655d30'
     );
   });
+
+  it('should accept big numbers as string', () => {
+    const unsigned = transfer(
+      {
+        ...TEST_METHOD_ARGS.balances.transfer,
+        value: '9007199254740996', // MAX_SAFE_INTEGER + 5
+      },
+      TEST_BASE_TX_INFO
+    );
+
+    testBaseTxInfo(unsigned);
+    expect(unsigned.method).toBe(
+      '0x060096074594cccf1cd185fa8a72ceaeefd86648f8d45514f3ce33c31bdd07e4655d0f04000000000020'
+    );
+  });
 });

--- a/src/methods/balances/transfer.ts
+++ b/src/methods/balances/transfer.ts
@@ -14,7 +14,7 @@ export interface BalancesTransferArgs extends Args {
   /**
    * The amount to send.
    */
-  value: number;
+  value: number | string;
 }
 
 /**

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -16,13 +16,3 @@ export const WESTEND_SS58_FORMAT = 42;
  * Latest extrinsic version.
  */
 export const EXTRINSIC_VERSION = 4;
-
-// Useful constants for calculting an Era.
-/**
- * @ignore
- */
-export const BLOCKTIME = 6; // in s
-/**
- * @ignore
- */
-export const ONE_SECOND = 1 / BLOCKTIME;

--- a/src/util/method.spec.ts
+++ b/src/util/method.spec.ts
@@ -16,6 +16,24 @@ describe('createMethod', () => {
       },
     });
 
-    expect(unsigned.era).toBe('0xe500'); // 0x00 means immortal, anything else is mortal
+    expect(unsigned.era).toBe('0xe500');
+  });
+
+  it('should be backwards-compatible with validityPeriod', () => {
+    const txBaseInfo = {
+      ...TEST_BASE_TX_INFO,
+      eraPeriod: undefined,
+      validityPeriod: 7200, // 2h
+    };
+    const unsigned = createMethod({
+      ...txBaseInfo,
+      method: {
+        args: {},
+        name: 'withdrawUnbonded',
+        pallet: 'staking',
+      },
+    });
+
+    expect(unsigned.era).toBe('0xea58');
   });
 });

--- a/src/util/method.spec.ts
+++ b/src/util/method.spec.ts
@@ -5,7 +5,7 @@ describe('createMethod', () => {
   it('should create a default validity period of 5 minutes', () => {
     const txBaseInfo = {
       ...TEST_BASE_TX_INFO,
-      validityPeriod: undefined,
+      eraPeriod: undefined,
     };
     const unsigned = createMethod({
       ...txBaseInfo,

--- a/src/util/method.ts
+++ b/src/util/method.ts
@@ -17,13 +17,13 @@ import { BaseTxInfo, UnsignedTransaction } from './types';
  */
 const DEFAULTS = {
   /**
-   * Don't add any tip by default
+   * Don't add any tip by default.
    */
   tip: 0,
   /**
-   * Construct a mortal extrinsic of ~5 minutes
+   * Construct a mortal extrinsic of ~6m24s minutes.
    */
-  eraPeriod: 50,
+  eraPeriod: 64,
 };
 
 export type Args = Record<string, AnyJson>;

--- a/src/util/method.ts
+++ b/src/util/method.ts
@@ -7,7 +7,7 @@ import { Call } from '@polkadot/types/interfaces';
 import { AnyJson } from '@polkadot/types/types';
 import { stringCamelCase } from '@polkadot/util';
 
-import { EXTRINSIC_VERSION, ONE_SECOND } from './constants';
+import { EXTRINSIC_VERSION } from './constants';
 import { createDecorated } from './metadata';
 import { Options, sanitizeOptions } from './options';
 import { BaseTxInfo, UnsignedTransaction } from './types';
@@ -23,7 +23,7 @@ const DEFAULTS = {
   /**
    * Construct a mortal extrinsic of ~5 minutes
    */
-  validityPeriod: 5 * 60,
+  eraPeriod: 50,
 };
 
 export type Args = Record<string, AnyJson>;
@@ -87,7 +87,7 @@ export function createMethod(
     era: registry
       .createType('ExtrinsicEra', {
         current: info.blockNumber,
-        period: ONE_SECOND * (info.validityPeriod || DEFAULTS.validityPeriod),
+        period: info.eraPeriod || DEFAULTS.eraPeriod,
       })
       .toHex(),
     genesisHash: info.genesisHash,

--- a/src/util/method.ts
+++ b/src/util/method.ts
@@ -80,6 +80,22 @@ export function createMethod(
     })
   ).toHex();
 
+  // We were accepting `validityPeriod` field, in seconds, before using
+  // `eraPeriod`, in blocks. This piece of code assures backward-compatibility.
+  if (info.validityPeriod) {
+    console.warn(
+      'The `validityPeriod` field in tx info is now deprecated. Please use `eraPeriod`, the period now being in blocks instead of seconds.'
+    );
+  }
+  const eraPeriod =
+    // If `info.eraPeriod` is set, use it.
+    info.eraPeriod ||
+    // For backwards-compatibility, also see if `info.validityPeriod` is set,
+    // with a block time of 6s.
+    (info.validityPeriod && info.validityPeriod / 6) ||
+    // As last resort, take the default value.
+    DEFAULTS.eraPeriod;
+
   return {
     address: info.address,
     blockHash: info.blockHash,
@@ -87,7 +103,7 @@ export function createMethod(
     era: registry
       .createType('ExtrinsicEra', {
         current: info.blockNumber,
-        period: info.eraPeriod || DEFAULTS.eraPeriod,
+        period: eraPeriod,
       })
       .toHex(),
     genesisHash: info.genesisHash,

--- a/src/util/testUtil.ts
+++ b/src/util/testUtil.ts
@@ -21,13 +21,13 @@ export const TEST_BASE_TX_INFO = {
   blockHash:
     '0x1fc7493f3c1e9ac758a183839906475f8363aafb1b1d3e910fe16fab4ae1b582',
   blockNumber: 4302222,
+  eraPeriod: 2400,
   genesisHash:
     '0xe3777fa922cafbff200cadeaea1a76bd7898ad5b89f7848999058b50e715f636',
   metadataRpc,
   nonce: 2,
   specVersion: 1019,
   tip: 0,
-  validityPeriod: 240 * 60,
 };
 
 /**

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -30,7 +30,7 @@ export interface BaseTxInfo {
   /**
    * Describe the longevity of a transaction. It represents the validity from
    * the `blockHash` field, in number of blocks. Defaults to 50 blocks, which
-   * represents ~5 minutes.
+   * translates to ~5 minutes.
    *
    * @default 50
    */
@@ -62,7 +62,7 @@ export interface BaseTxInfo {
    * The amount of time (in second) the transaction is valid for. Will be
    * translated into a mortal era. Defaults to 5 minutes.
    *
-   * @deprecated
+   * @deprecated Please use `eraPeriod` instead.
    * @default 300
    */
   validityPeriod?: number;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -28,6 +28,14 @@ export interface BaseTxInfo {
    */
   blockNumber: number;
   /**
+   * Describe the longevity of a transaction. It represents the validity from
+   * the `blockHash` field, in number of blocks. Defaults to 50 blocks, which
+   * represents ~5 minutes.
+   *
+   * @default 50
+   */
+  eraPeriod?: number;
+  /**
    * The genesis hash of the chain, in hex.
    */
   genesisHash: string;
@@ -54,6 +62,7 @@ export interface BaseTxInfo {
    * The amount of time (in second) the transaction is valid for. Will be
    * translated into a mortal era. Defaults to 5 minutes.
    *
+   * @deprecated
    * @default 300
    */
   validityPeriod?: number;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -29,10 +29,9 @@ export interface BaseTxInfo {
   blockNumber: number;
   /**
    * Describe the longevity of a transaction. It represents the validity from
-   * the `blockHash` field, in number of blocks. Defaults to 50 blocks, which
-   * translates to ~5 minutes.
+   * the `blockHash` field, in number of blocks. Defaults to 64 blocks.
    *
-   * @default 50
+   * @default 64
    */
   eraPeriod?: number;
   /**


### PR DESCRIPTION
A warning is showed when using `validityPeriod` now.

also fixes #132 