### PR TITLE
Update bash commands in examples/ReadMe.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,7 @@ polkadot --dev
 ```bash
 ./node_modules/.bin/ts-node examples/substrateMaster.ts
 # or
-./node_modules/.bin/ts-node examples/kusama.ts
+./node_modules/.bin/ts-node examples/polkadot.ts
 ```
 
 ## Expected Output

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,9 +18,9 @@ polkadot --dev
 2. Run the example script in this folder. It will interact with your local node.
 
 ```bash
-./node_module/.bin/ts-node example/substrateMaster.ts
+./node_modules/.bin/ts-node examples/substrateMaster.ts
 # or
-./node_module/.bin/ts-node example/kusama.ts
+./node_modules/.bin/ts-node examples/kusama.ts
 ```
 
 ## Expected Output


### PR DESCRIPTION
The bash commands in the `examples/ReadMe.md` should reflect the correct name of the `node_modules` folder and the `examples` folder. Additionally, there is command for a `kusama.ts` example which does not exist as far as I can tell so I replaced it with the `polkadot.ts` example.