### PR TITLE
Export `PollVoteArgs` interface

### DIFF
--- a/src/methods/poll/vote.ts
+++ b/src/methods/poll/vote.ts
@@ -6,7 +6,7 @@ import {
   UnsignedTransaction,
 } from '../../util';
 
-interface PollVoteArgs extends Args {
+export interface PollVoteArgs extends Args {
   /**
    * The options to vote for. Must be a boolean array of length 4.
    */


### PR DESCRIPTION
Unlike all other methods, the `PollVoteArgs` isn't being exported. This exports it :)