### PR TITLE
feat: Add optional `toInt` flag on decode methods

### DIFF
--- a/docs/interfaces/_src_methods_balances_transfer_.balancestransferargs.md
+++ b/docs/interfaces/_src_methods_balances_transfer_.balancestransferargs.md
@@ -21,7 +21,7 @@
 
 • **dest**: *string*
 
-*Defined in [src/methods/balances/transfer.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/balances/transfer.ts#L13)*
+*Defined in [src/methods/balances/transfer.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/balances/transfer.ts#L13)*
 
 The recipient address, SS-58 encoded.
 
@@ -31,6 +31,6 @@ ___
 
 • **value**: *number | string*
 
-*Defined in [src/methods/balances/transfer.ts:17](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/balances/transfer.ts#L17)*
+*Defined in [src/methods/balances/transfer.ts:17](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/balances/transfer.ts#L17)*
 
 The amount to send.

--- a/docs/interfaces/_src_methods_claims_attest_.claimsattestargs.md
+++ b/docs/interfaces/_src_methods_claims_attest_.claimsattestargs.md
@@ -20,6 +20,6 @@
 
 • **statement**: *string*
 
-*Defined in [src/methods/claims/attest.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/claims/attest.ts#L13)*
+*Defined in [src/methods/claims/attest.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/claims/attest.ts#L13)*
 
 The identity of the statement that is being attested to in the signature.

--- a/docs/interfaces/_src_methods_claims_claimattest_.claimsclaimattestargs.md
+++ b/docs/interfaces/_src_methods_claims_claimattest_.claimsclaimattestargs.md
@@ -22,7 +22,7 @@
 
 • **dest**: *string*
 
-*Defined in [src/methods/claims/claimAttest.ts:14](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/claims/claimAttest.ts#L14)*
+*Defined in [src/methods/claims/claimAttest.ts:14](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/claims/claimAttest.ts#L14)*
 
 The destination account to which to pay out the claim. This method is only
 available on Polkadot.
@@ -33,7 +33,7 @@ ___
 
 • **ethereumSignature**: *string*
 
-*Defined in [src/methods/claims/claimAttest.ts:19](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/claims/claimAttest.ts#L19)*
+*Defined in [src/methods/claims/claimAttest.ts:19](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/claims/claimAttest.ts#L19)*
 
 The signature of an Ethereum signed message matching the format described
 above.
@@ -44,6 +44,6 @@ ___
 
 • **statement**: *string*
 
-*Defined in [src/methods/claims/claimAttest.ts:23](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/claims/claimAttest.ts#L23)*
+*Defined in [src/methods/claims/claimAttest.ts:23](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/claims/claimAttest.ts#L23)*
 
 The identity of the statement that is being attested to in the signature.

--- a/docs/interfaces/_src_methods_democracy_activateproxy_.democracyactivateproxyargs.md
+++ b/docs/interfaces/_src_methods_democracy_activateproxy_.democracyactivateproxyargs.md
@@ -20,6 +20,6 @@
 
 • **proxy**: *string*
 
-*Defined in [src/methods/democracy/activateProxy.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/activateProxy.ts#L13)*
+*Defined in [src/methods/democracy/activateProxy.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/activateProxy.ts#L13)*
 
 Address to set as proxy, SS-58 encoded.

--- a/docs/interfaces/_src_methods_democracy_deactivateproxy_.democracydeactivateproxyargs.md
+++ b/docs/interfaces/_src_methods_democracy_deactivateproxy_.democracydeactivateproxyargs.md
@@ -20,6 +20,6 @@
 
 • **proxy**: *string*
 
-*Defined in [src/methods/democracy/deactivateProxy.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/deactivateProxy.ts#L13)*
+*Defined in [src/methods/democracy/deactivateProxy.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/deactivateProxy.ts#L13)*
 
 The address of the proxy to remove, SS-58 encoded.

--- a/docs/interfaces/_src_methods_democracy_openproxy_.democracyopenproxyargs.md
+++ b/docs/interfaces/_src_methods_democracy_openproxy_.democracyopenproxyargs.md
@@ -20,6 +20,6 @@
 
 • **target**: *string*
 
-*Defined in [src/methods/democracy/openProxy.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/openProxy.ts#L13)*
+*Defined in [src/methods/democracy/openProxy.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/openProxy.ts#L13)*
 
 The address of the proxy to remove, SS-58 encoded.

--- a/docs/interfaces/_src_methods_democracy_proxyvote_.democracyproxyvoteargs.md
+++ b/docs/interfaces/_src_methods_democracy_proxyvote_.democracyproxyvoteargs.md
@@ -21,7 +21,7 @@
 
 • **refIndex**: *number*
 
-*Defined in [src/methods/democracy/proxyVote.ts:14](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/proxyVote.ts#L14)*
+*Defined in [src/methods/democracy/proxyVote.ts:14](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/proxyVote.ts#L14)*
 
 ___
 
@@ -29,6 +29,6 @@ ___
 
 • **vote**: *[AccountVote](../modules/_src_methods_democracy_types_.md#accountvote)*
 
-*Defined in [src/methods/democracy/proxyVote.ts:18](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/proxyVote.ts#L18)*
+*Defined in [src/methods/democracy/proxyVote.ts:18](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/proxyVote.ts#L18)*
 
 Vote.

--- a/docs/interfaces/_src_methods_democracy_vote_.democracyvoteargs.md
+++ b/docs/interfaces/_src_methods_democracy_vote_.democracyvoteargs.md
@@ -21,7 +21,7 @@
 
 • **refIndex**: *number*
 
-*Defined in [src/methods/democracy/vote.ts:14](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/vote.ts#L14)*
+*Defined in [src/methods/democracy/vote.ts:14](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/vote.ts#L14)*
 
 ___
 
@@ -29,6 +29,6 @@ ___
 
 • **vote**: *[AccountVote](../modules/_src_methods_democracy_types_.md#accountvote)*
 
-*Defined in [src/methods/democracy/vote.ts:18](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/vote.ts#L18)*
+*Defined in [src/methods/democracy/vote.ts:18](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/vote.ts#L18)*
 
 Vote.

--- a/docs/interfaces/_src_methods_poll_vote_.pollvoteargs.md
+++ b/docs/interfaces/_src_methods_poll_vote_.pollvoteargs.md
@@ -20,6 +20,6 @@
 
 • **approvals**: *boolean[]*
 
-*Defined in [src/methods/poll/vote.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/poll/vote.ts#L13)*
+*Defined in [src/methods/poll/vote.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/poll/vote.ts#L13)*
 
 The options to vote for. Must be a boolean array of length 4.

--- a/docs/interfaces/_src_methods_proxy_addproxy_.proxyaddproxy.md
+++ b/docs/interfaces/_src_methods_proxy_addproxy_.proxyaddproxy.md
@@ -21,7 +21,7 @@
 
 • **proxy**: *string*
 
-*Defined in [src/methods/proxy/addProxy.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/proxy/addProxy.ts#L13)*
+*Defined in [src/methods/proxy/addProxy.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/proxy/addProxy.ts#L13)*
 
 The account that the `caller` would like to make a proxy.
 
@@ -31,7 +31,7 @@ ___
 
 • **proxyType**: *string*
 
-*Defined in [src/methods/proxy/addProxy.ts:23](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/proxy/addProxy.ts#L23)*
+*Defined in [src/methods/proxy/addProxy.ts:23](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/proxy/addProxy.ts#L23)*
 
 The permissions for this proxy account. See the runtime for the `call` filters.
 Current known types (Polkadot v8, Kusama v2008, Westend v28):

--- a/docs/interfaces/_src_methods_proxy_proxy_.proxyproxy.md
+++ b/docs/interfaces/_src_methods_proxy_proxy_.proxyproxy.md
@@ -22,7 +22,7 @@
 
 • **call**: *object | string*
 
-*Defined in [src/methods/proxy/proxy.ts:23](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/proxy/proxy.ts#L23)*
+*Defined in [src/methods/proxy/proxy.ts:23](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/proxy/proxy.ts#L23)*
 
 The call to be made by the `real` account.
 To take advantage of txwrapper methods, this could be UnsignedTransaction.method.
@@ -33,7 +33,7 @@ ___
 
 • **forceProxyType**: *string*
 
-*Defined in [src/methods/proxy/proxy.ts:18](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/proxy/proxy.ts#L18)*
+*Defined in [src/methods/proxy/proxy.ts:18](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/proxy/proxy.ts#L18)*
 
 Specify the exact proxy type to be used and checked for this call.
 
@@ -43,7 +43,7 @@ ___
 
 • **real**: *string*
 
-*Defined in [src/methods/proxy/proxy.ts:14](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/proxy/proxy.ts#L14)*
+*Defined in [src/methods/proxy/proxy.ts:14](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/proxy/proxy.ts#L14)*
 
 Dispatch the given `call` from an account that the sender is authorized for
  through, `add_proxy`.

--- a/docs/interfaces/_src_methods_proxy_removeproxy_.proxyremoveproxy.md
+++ b/docs/interfaces/_src_methods_proxy_removeproxy_.proxyremoveproxy.md
@@ -21,7 +21,7 @@
 
 • **proxy**: *string*
 
-*Defined in [src/methods/proxy/removeProxy.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/proxy/removeProxy.ts#L13)*
+*Defined in [src/methods/proxy/removeProxy.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/proxy/removeProxy.ts#L13)*
 
 The account that the `caller` would like to unregister.
 
@@ -31,6 +31,6 @@ ___
 
 • **proxyType**: *string*
 
-*Defined in [src/methods/proxy/removeProxy.ts:17](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/proxy/removeProxy.ts#L17)*
+*Defined in [src/methods/proxy/removeProxy.ts:17](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/proxy/removeProxy.ts#L17)*
 
 The permissions currently enabled for the target proxy account.

--- a/docs/interfaces/_src_methods_session_setkeys_.sessionsetkeysargs.md
+++ b/docs/interfaces/_src_methods_session_setkeys_.sessionsetkeysargs.md
@@ -21,7 +21,7 @@
 
 • **keys**: *string[]*
 
-*Defined in [src/methods/session/setKeys.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/session/setKeys.ts#L13)*
+*Defined in [src/methods/session/setKeys.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/session/setKeys.ts#L13)*
 
 The 5 keys to set.
 
@@ -31,6 +31,6 @@ ___
 
 • **proof**? : *undefined | string*
 
-*Defined in [src/methods/session/setKeys.ts:17](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/session/setKeys.ts#L17)*
+*Defined in [src/methods/session/setKeys.ts:17](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/session/setKeys.ts#L17)*
 
 Proof (unused for now).

--- a/docs/interfaces/_src_methods_staking_bond_.stakingbondargs.md
+++ b/docs/interfaces/_src_methods_staking_bond_.stakingbondargs.md
@@ -22,7 +22,7 @@
 
 • **controller**: *string*
 
-*Defined in [src/methods/staking/bond.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/bond.ts#L13)*
+*Defined in [src/methods/staking/bond.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/bond.ts#L13)*
 
 The SS-58 encoded address of the Controller account.
 
@@ -32,7 +32,7 @@ ___
 
 • **payee**: *string*
 
-*Defined in [src/methods/staking/bond.ts:21](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/bond.ts#L21)*
+*Defined in [src/methods/staking/bond.ts:21](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/bond.ts#L21)*
 
 The rewards destination. Can be "Stash", "Staked", or "Controller".
 
@@ -42,6 +42,6 @@ ___
 
 • **value**: *number*
 
-*Defined in [src/methods/staking/bond.ts:17](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/bond.ts#L17)*
+*Defined in [src/methods/staking/bond.ts:17](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/bond.ts#L17)*
 
 The number of tokens to bond.

--- a/docs/interfaces/_src_methods_staking_bondextra_.stakingbondextraargs.md
+++ b/docs/interfaces/_src_methods_staking_bondextra_.stakingbondextraargs.md
@@ -20,6 +20,6 @@
 
 • **maxAdditional**: *number*
 
-*Defined in [src/methods/staking/bondExtra.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/bondExtra.ts#L13)*
+*Defined in [src/methods/staking/bondExtra.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/bondExtra.ts#L13)*
 
 The maximum amount to bond.

--- a/docs/interfaces/_src_methods_staking_nominate_.stakingnominateargs.md
+++ b/docs/interfaces/_src_methods_staking_nominate_.stakingnominateargs.md
@@ -20,7 +20,7 @@
 
 • **targets**: *Array‹string›*
 
-*Defined in [src/methods/staking/nominate.ts:16](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/nominate.ts#L16)*
+*Defined in [src/methods/staking/nominate.ts:16](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/nominate.ts#L16)*
 
 The SS-58 encoded addresses of the targets you wish to nominate. A maximum of 16
 nominations are allowed.

--- a/docs/interfaces/_src_methods_staking_payoutnominator_.stakingpayoutnominatorargs.md
+++ b/docs/interfaces/_src_methods_staking_payoutnominator_.stakingpayoutnominatorargs.md
@@ -21,7 +21,7 @@
 
 • **era**: *number*
 
-*Defined in [src/methods/staking/payoutNominator.ts:15](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/payoutNominator.ts#L15)*
+*Defined in [src/methods/staking/payoutNominator.ts:15](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/payoutNominator.ts#L15)*
 
 May not be lower than one following the most recently paid era. If it is
 higher, then it indicates an instruction to skip the payout of all
@@ -33,7 +33,7 @@ ___
 
 • **validators**: *[string, number][]*
 
-*Defined in [src/methods/staking/payoutNominator.ts:22](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/payoutNominator.ts#L22)*
+*Defined in [src/methods/staking/payoutNominator.ts:22](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/payoutNominator.ts#L22)*
 
 List of all validators that `who` had exposure to during `era` alongside
 the index of the `who` in the clipped exposure of the validator. i.e. each

--- a/docs/interfaces/_src_methods_staking_payoutstakers_.stakingpayoutstakersargs.md
+++ b/docs/interfaces/_src_methods_staking_payoutstakers_.stakingpayoutstakersargs.md
@@ -21,7 +21,7 @@
 
 • **era**: *number | string*
 
-*Defined in [src/methods/staking/payoutStakers.ts:19](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/payoutStakers.ts#L19)*
+*Defined in [src/methods/staking/payoutStakers.ts:19](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/payoutStakers.ts#L19)*
 
 May be any era between `[current_era - history_depth; current_era]`. Substrate only
 retains up to `history_depth` eras of reward information.
@@ -32,7 +32,7 @@ ___
 
 • **validatorStash**: *string*
 
-*Defined in [src/methods/staking/payoutStakers.ts:14](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/payoutStakers.ts#L14)*
+*Defined in [src/methods/staking/payoutStakers.ts:14](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/payoutStakers.ts#L14)*
 
 The Stash account of a _validator._ Their nominators, up to, the maximum
 `MaxNominatorRewardedPerValidator`, will also receive their rewards.

--- a/docs/interfaces/_src_methods_staking_payoutvalidator_.stakingpayoutvalidatorargs.md
+++ b/docs/interfaces/_src_methods_staking_payoutvalidator_.stakingpayoutvalidatorargs.md
@@ -20,7 +20,7 @@
 
 • **era**: *number*
 
-*Defined in [src/methods/staking/payoutValidator.ts:15](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/payoutValidator.ts#L15)*
+*Defined in [src/methods/staking/payoutValidator.ts:15](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/payoutValidator.ts#L15)*
 
 May not be lower than one following the most recently paid era. If it is
 higher, then it indicates an instruction to skip the payout of all

--- a/docs/interfaces/_src_methods_staking_rebond_.stakingrebondargs.md
+++ b/docs/interfaces/_src_methods_staking_rebond_.stakingrebondargs.md
@@ -20,6 +20,6 @@
 
 • **value**: *number | string*
 
-*Defined in [src/methods/staking/rebond.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/rebond.ts#L13)*
+*Defined in [src/methods/staking/rebond.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/rebond.ts#L13)*
 
 The number of tokens to rebond.

--- a/docs/interfaces/_src_methods_staking_setcontroller_.stakingsetcontrollerargs.md
+++ b/docs/interfaces/_src_methods_staking_setcontroller_.stakingsetcontrollerargs.md
@@ -20,6 +20,6 @@
 
 • **controller**: *string*
 
-*Defined in [src/methods/staking/setController.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/setController.ts#L13)*
+*Defined in [src/methods/staking/setController.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/setController.ts#L13)*
 
 The SS-58 encoded controller address.

--- a/docs/interfaces/_src_methods_staking_setpayee_.stakingsetpayeeargs.md
+++ b/docs/interfaces/_src_methods_staking_setpayee_.stakingsetpayeeargs.md
@@ -20,6 +20,6 @@
 
 • **payee**: *string*
 
-*Defined in [src/methods/staking/setPayee.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/setPayee.ts#L13)*
+*Defined in [src/methods/staking/setPayee.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/setPayee.ts#L13)*
 
 The `RewardDestination`. It can be one of 'Staking', 'Stash', or 'Controller'.

--- a/docs/interfaces/_src_methods_staking_unbond_.stakingunbondargs.md
+++ b/docs/interfaces/_src_methods_staking_unbond_.stakingunbondargs.md
@@ -20,6 +20,6 @@
 
 • **value**: *number*
 
-*Defined in [src/methods/staking/unbond.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/unbond.ts#L13)*
+*Defined in [src/methods/staking/unbond.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/unbond.ts#L13)*
 
 The number of tokens to unbond.

--- a/docs/interfaces/_src_methods_staking_validate_.stakingvalidateargs.md
+++ b/docs/interfaces/_src_methods_staking_validate_.stakingvalidateargs.md
@@ -20,7 +20,7 @@
 
 • **prefs**: *object*
 
-*Defined in [src/methods/staking/validate.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/validate.ts#L13)*
+*Defined in [src/methods/staking/validate.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/validate.ts#L13)*
 
 Set the desired commission for the validator. Value is Perbill.
 

--- a/docs/interfaces/_src_methods_staking_withdrawunbonded_.stakingwithdrawunbondedargs.md
+++ b/docs/interfaces/_src_methods_staking_withdrawunbonded_.stakingwithdrawunbondedargs.md
@@ -20,4 +20,4 @@
 
 • **numSlashingSpans**: *number*
 
-*Defined in [src/methods/staking/withdrawUnbonded.ts:10](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/withdrawUnbonded.ts#L10)*
+*Defined in [src/methods/staking/withdrawUnbonded.ts:10](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/withdrawUnbonded.ts#L10)*

--- a/docs/interfaces/_src_methods_system_remark_.systemremarkargs.md
+++ b/docs/interfaces/_src_methods_system_remark_.systemremarkargs.md
@@ -20,6 +20,6 @@
 
 • **remark**: *string*
 
-*Defined in [src/methods/system/remark.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/system/remark.ts#L13)*
+*Defined in [src/methods/system/remark.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/system/remark.ts#L13)*
 
 The remark to set on chain, in hex or bytes.

--- a/docs/interfaces/_src_methods_utility_batch_.utilitybatch.md
+++ b/docs/interfaces/_src_methods_utility_batch_.utilitybatch.md
@@ -18,9 +18,9 @@
 
 ###  calls
 
-• **calls**: *string | object[]*
+• **calls**: *(string | object)[]*
 
-*Defined in [src/methods/utility/batch.ts:15](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/utility/batch.ts#L15)*
+*Defined in [src/methods/utility/batch.ts:15](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/utility/batch.ts#L15)*
 
 The calls to be dispatched from the same origin.
 To take advantage of txwrapper methods, this could be an array of

--- a/docs/interfaces/_src_methods_vesting_vestother_.vestingvestotherargs.md
+++ b/docs/interfaces/_src_methods_vesting_vestother_.vestingvestotherargs.md
@@ -20,7 +20,7 @@
 
 • **target**: *string*
 
-*Defined in [src/methods/vesting/vestOther.ts:14](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/vesting/vestOther.ts#L14)*
+*Defined in [src/methods/vesting/vestOther.ts:14](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/vesting/vestOther.ts#L14)*
 
 The account whose vested funds should be unlocked. Must have funds still
 locked under this module.

--- a/docs/interfaces/_src_util_claims_.polkadotstatement.md
+++ b/docs/interfaces/_src_util_claims_.polkadotstatement.md
@@ -22,7 +22,7 @@ Object representing a Polkadot statement.
 
 • **hash**: *string*
 
-*Defined in [src/util/claims.ts:15](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/claims.ts#L15)*
+*Defined in [src/util/claims.ts:15](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/claims.ts#L15)*
 
 The statement's SHA-256 multihash.
 
@@ -32,7 +32,7 @@ ___
 
 • **sentence**: *string*
 
-*Defined in [src/util/claims.ts:19](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/claims.ts#L19)*
+*Defined in [src/util/claims.ts:19](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/claims.ts#L19)*
 
 The English human-readable sentence to sign.
 
@@ -42,6 +42,6 @@ ___
 
 • **url**: *string*
 
-*Defined in [src/util/claims.ts:23](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/claims.ts#L23)*
+*Defined in [src/util/claims.ts:23](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/claims.ts#L23)*
 
 The url at which the statement is hosted.

--- a/docs/interfaces/_src_util_metadata_.chainproperties.md
+++ b/docs/interfaces/_src_util_metadata_.chainproperties.md
@@ -22,7 +22,7 @@ JSON object of ChainProperties codec from `@polkadot/api`.
 
 • **ss58Format**: *number*
 
-*Defined in [src/util/metadata.ts:16](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/metadata.ts#L16)*
+*Defined in [src/util/metadata.ts:16](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/metadata.ts#L16)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **tokenDecimals**: *number*
 
-*Defined in [src/util/metadata.ts:17](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/metadata.ts#L17)*
+*Defined in [src/util/metadata.ts:17](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/metadata.ts#L17)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 • **tokenSymbol**: *string*
 
-*Defined in [src/util/metadata.ts:18](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/metadata.ts#L18)*
+*Defined in [src/util/metadata.ts:18](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/metadata.ts#L18)*

--- a/docs/interfaces/_src_util_types_.basetxinfo.md
+++ b/docs/interfaces/_src_util_types_.basetxinfo.md
@@ -30,7 +30,7 @@ JSON format for information that is common to all transactions.
 
 • **address**: *string*
 
-*Defined in [src/util/types.ts:22](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L22)*
+*Defined in [src/util/types.ts:22](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L22)*
 
 The ss-58 encoded address of the sending account.
 
@@ -40,7 +40,7 @@ ___
 
 • **blockHash**: *string*
 
-*Defined in [src/util/types.ts:26](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L26)*
+*Defined in [src/util/types.ts:26](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L26)*
 
 The checkpoint hash of the block, in hex.
 
@@ -50,7 +50,7 @@ ___
 
 • **blockNumber**: *number*
 
-*Defined in [src/util/types.ts:30](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L30)*
+*Defined in [src/util/types.ts:30](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L30)*
 
 The checkpoint block number (u32), in hex.
 
@@ -60,7 +60,7 @@ ___
 
 • **eraPeriod**? : *undefined | number*
 
-*Defined in [src/util/types.ts:37](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L37)*
+*Defined in [src/util/types.ts:37](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L37)*
 
 Describe the longevity of a transaction. It represents the validity from
 the `blockHash` field, in number of blocks. Defaults to 64 blocks.
@@ -73,7 +73,7 @@ ___
 
 • **genesisHash**: *string*
 
-*Defined in [src/util/types.ts:41](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L41)*
+*Defined in [src/util/types.ts:41](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L41)*
 
 The genesis hash of the chain, in hex.
 
@@ -83,7 +83,7 @@ ___
 
 • **metadataRpc**: *string*
 
-*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L46)*
+*Defined in [src/util/types.ts:46](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L46)*
 
 The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC
 call `state_getMetadata`.
@@ -94,7 +94,7 @@ ___
 
 • **nonce**: *number*
 
-*Defined in [src/util/types.ts:50](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L50)*
+*Defined in [src/util/types.ts:50](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L50)*
 
 The nonce for this transaction.
 
@@ -104,7 +104,7 @@ ___
 
 • **specVersion**: *number*
 
-*Defined in [src/util/types.ts:54](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L54)*
+*Defined in [src/util/types.ts:54](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L54)*
 
 The current spec version for the runtime.
 
@@ -114,7 +114,7 @@ ___
 
 • **tip**? : *undefined | number*
 
-*Defined in [src/util/types.ts:60](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L60)*
+*Defined in [src/util/types.ts:60](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L60)*
 
 The tip for this transaction, in hex.
 
@@ -126,7 +126,7 @@ ___
 
 • **transactionVersion**: *number*
 
-*Defined in [src/util/types.ts:64](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L64)*
+*Defined in [src/util/types.ts:64](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L64)*
 
 The current transaction version for the runtime.
 
@@ -136,7 +136,7 @@ ___
 
 • **validityPeriod**? : *undefined | number*
 
-*Defined in [src/util/types.ts:72](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L72)*
+*Defined in [src/util/types.ts:72](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L72)*
 
 The amount of time (in second) the transaction is valid for. Will be
 translated into a mortal era. Defaults to 5 minutes.

--- a/docs/interfaces/_src_util_types_.options.md
+++ b/docs/interfaces/_src_util_types_.options.md
@@ -23,6 +23,6 @@ functions that only require registry.
 
 • **registry**: *TypeRegistry*
 
-*Defined in [src/util/types.ts:83](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L83)*
+*Defined in [src/util/types.ts:83](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L83)*
 
 The type registry of the runtime.

--- a/docs/interfaces/_src_util_types_.optionswithmeta.md
+++ b/docs/interfaces/_src_util_types_.optionswithmeta.md
@@ -24,7 +24,7 @@ options to functions that require registry and metadata.
 
 • **metadataRpc**: *string*
 
-*Defined in [src/util/types.ts:94](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L94)*
+*Defined in [src/util/types.ts:94](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L94)*
 
 The metadata of the runtime.
 
@@ -36,6 +36,6 @@ ___
 
 *Inherited from [Options](_src_util_types_.options.md).[registry](_src_util_types_.options.md#registry)*
 
-*Defined in [src/util/types.ts:83](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L83)*
+*Defined in [src/util/types.ts:83](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L83)*
 
 The type registry of the runtime.

--- a/docs/interfaces/_src_util_types_.unsignedtransaction.md
+++ b/docs/interfaces/_src_util_types_.unsignedtransaction.md
@@ -94,7 +94,7 @@ ___
 
 • **metadataRpc**: *string*
 
-*Defined in [src/util/types.ts:12](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/types.ts#L12)*
+*Defined in [src/util/types.ts:12](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/types.ts#L12)*
 
 The SCALE-encoded metadata, as a hex string. Can be retrieved via the RPC
 call `state_getMetadata`.

--- a/docs/modules/_src_createsignedtx_.md
+++ b/docs/modules/_src_createsignedtx_.md
@@ -14,7 +14,7 @@
 
 ▸ **createSignedTx**(`unsigned`: [UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md), `signature`: string, `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *string*
 
-*Defined in [src/createSignedTx.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/createSignedTx.ts#L13)*
+*Defined in [src/createSignedTx.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/createSignedTx.ts#L13)*
 
 Serialize a signed transaction in a format that can be submitted over the
 Node RPC Interface from the signing payload and signature produced by the

--- a/docs/modules/_src_createsigningpayload_.md
+++ b/docs/modules/_src_createsigningpayload_.md
@@ -14,7 +14,7 @@
 
 ▸ **createSigningPayload**(`unsigned`: [UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md), `options`: [Options](../interfaces/_src_util_types_.options.md)): *string*
 
-*Defined in [src/createSigningPayload.ts:45](https://github.com/paritytech/txwrapper/blob/e82a68c/src/createSigningPayload.ts#L45)*
+*Defined in [src/createSigningPayload.ts:45](https://github.com/paritytech/txwrapper/blob/2e195b6/src/createSigningPayload.ts#L45)*
 
 Construct the signing payload from an unsigned transaction and export it to
 a remote signer (this is often called "detached signing").

--- a/docs/modules/_src_decode_decode_.md
+++ b/docs/modules/_src_decode_decode_.md
@@ -12,9 +12,9 @@
 
 ###  decode
 
-▸ **decode**(`unsignedTx`: [UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *DecodedUnsignedTx*
+▸ **decode**(`unsignedTx`: [UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md), `toInt?`: undefined | false | true): *DecodedUnsignedTx*
 
-*Defined in [src/decode/decode.ts:15](https://github.com/paritytech/txwrapper/blob/e82a68c/src/decode/decode.ts#L15)*
+*Defined in [src/decode/decode.ts:18](https://github.com/paritytech/txwrapper/blob/2e195b6/src/decode/decode.ts#L18)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 
@@ -23,13 +23,14 @@ Parse the transaction information from a signing payload, an unsigned tx, or a s
 Name | Type | Description |
 ------ | ------ | ------ |
 `unsignedTx` | [UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md) | The data to parse, as an unsigned tx. |
-`options` | [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md) | Runtime-specific data used for decoding the transaction.  |
+`options` | [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md) | Runtime-specific data used for decoding the transaction. |
+`toInt?` | undefined &#124; false &#124; true | Whether or not to forcibly serialize integers in the call args to base-10 strings. If false, integers will either be a number or hex. Defaults to false  |
 
 **Returns:** *DecodedUnsignedTx*
 
-▸ **decode**(`signedTx`: string, `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *DecodedSignedTx*
+▸ **decode**(`signedTx`: string, `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md), `toInt?`: undefined | false | true): *DecodedSignedTx*
 
-*Defined in [src/decode/decode.ts:26](https://github.com/paritytech/txwrapper/blob/e82a68c/src/decode/decode.ts#L26)*
+*Defined in [src/decode/decode.ts:33](https://github.com/paritytech/txwrapper/blob/2e195b6/src/decode/decode.ts#L33)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 
@@ -38,13 +39,14 @@ Parse the transaction information from a signing payload, an unsigned tx, or a s
 Name | Type | Description |
 ------ | ------ | ------ |
 `signedTx` | string | The data to parse, as a signed tx hex string. |
-`options` | [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md) | Runtime-specific data used for decoding the transaction.  |
+`options` | [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md) | Runtime-specific data used for decoding the transaction. |
+`toInt?` | undefined &#124; false &#124; true | Whether or not to forcibly serialize integers in the call args to base-10 strings. If false, integers will either be a number or hex. Defaults to false  |
 
 **Returns:** *DecodedSignedTx*
 
-▸ **decode**(`signingPayload`: string, `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *DecodedSigningPayload*
+▸ **decode**(`signingPayload`: string, `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md), `toInt?`: undefined | false | true): *DecodedSigningPayload*
 
-*Defined in [src/decode/decode.ts:37](https://github.com/paritytech/txwrapper/blob/e82a68c/src/decode/decode.ts#L37)*
+*Defined in [src/decode/decode.ts:48](https://github.com/paritytech/txwrapper/blob/2e195b6/src/decode/decode.ts#L48)*
 
 Parse the transaction information from a signing payload, an unsigned tx, or a signed tx.
 
@@ -53,6 +55,7 @@ Parse the transaction information from a signing payload, an unsigned tx, or a s
 Name | Type | Description |
 ------ | ------ | ------ |
 `signingPayload` | string | The data to parse, as a signing payload hex string. |
-`options` | [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md) | Runtime-specific data used for decoding the transaction.  |
+`options` | [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md) | Runtime-specific data used for decoding the transaction. |
+`toInt?` | undefined &#124; false &#124; true | Whether or not to forcibly serialize integers in the call args to base-10 strings. If false, integers will either be a number or hex. Defaults to false  |
 
 **Returns:** *DecodedSigningPayload*

--- a/docs/modules/_src_deriveaddress_.md
+++ b/docs/modules/_src_deriveaddress_.md
@@ -14,7 +14,7 @@
 
 ▸ **deriveAddress**(`publicKey`: string | Uint8Array, `ss58Format`: number): *string*
 
-*Defined in [src/deriveAddress.ts:9](https://github.com/paritytech/txwrapper/blob/e82a68c/src/deriveAddress.ts#L9)*
+*Defined in [src/deriveAddress.ts:9](https://github.com/paritytech/txwrapper/blob/2e195b6/src/deriveAddress.ts#L9)*
 
 Derive an address from a cryptographic public key offline.
 

--- a/docs/modules/_src_gettxhash_.md
+++ b/docs/modules/_src_gettxhash_.md
@@ -14,7 +14,7 @@
 
 ▸ **getTxHash**(`signedTx`: string): *string*
 
-*Defined in [src/getTxHash.ts:8](https://github.com/paritytech/txwrapper/blob/e82a68c/src/getTxHash.ts#L8)*
+*Defined in [src/getTxHash.ts:8](https://github.com/paritytech/txwrapper/blob/2e195b6/src/getTxHash.ts#L8)*
 
 Derive the tx hash of a signed transaction offline.
 

--- a/docs/modules/_src_importprivatekey_.md
+++ b/docs/modules/_src_importprivatekey_.md
@@ -18,7 +18,7 @@
 
 Ƭ **KeyringPair**: *KeyringPairBase*
 
-*Defined in [src/importPrivateKey.ts:10](https://github.com/paritytech/txwrapper/blob/e82a68c/src/importPrivateKey.ts#L10)*
+*Defined in [src/importPrivateKey.ts:10](https://github.com/paritytech/txwrapper/blob/2e195b6/src/importPrivateKey.ts#L10)*
 
 A keyring pair
 
@@ -28,7 +28,7 @@ A keyring pair
 
 ▸ **importPrivateKey**(`privateKey`: string | Uint8Array, `ss58Format`: number): *KeyringPair*
 
-*Defined in [src/importPrivateKey.ts:18](https://github.com/paritytech/txwrapper/blob/e82a68c/src/importPrivateKey.ts#L18)*
+*Defined in [src/importPrivateKey.ts:18](https://github.com/paritytech/txwrapper/blob/2e195b6/src/importPrivateKey.ts#L18)*
 
 Import a private key and create a KeyringPair.
 

--- a/docs/modules/_src_methods_balances_transfer_.md
+++ b/docs/modules/_src_methods_balances_transfer_.md
@@ -18,7 +18,7 @@
 
 ▸ **transfer**(`args`: [BalancesTransferArgs](../interfaces/_src_methods_balances_transfer_.balancestransferargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/balances/transfer.ts:27](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/balances/transfer.ts#L27)*
+*Defined in [src/methods/balances/transfer.ts:27](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/balances/transfer.ts#L27)*
 
 Construct a balance transfer transaction offline.
 

--- a/docs/modules/_src_methods_balances_transferkeepalive_.md
+++ b/docs/modules/_src_methods_balances_transferkeepalive_.md
@@ -18,7 +18,7 @@
 
 Ƭ **BalancesTransferKeepAliveArgs**: *[BalancesTransferArgs](../interfaces/_src_methods_balances_transfer_.balancestransferargs.md)*
 
-*Defined in [src/methods/balances/transferKeepAlive.ts:9](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/balances/transferKeepAlive.ts#L9)*
+*Defined in [src/methods/balances/transferKeepAlive.ts:9](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/balances/transferKeepAlive.ts#L9)*
 
 ## Functions
 
@@ -26,7 +26,7 @@
 
 ▸ **transferKeepAlive**(`args`: [BalancesTransferKeepAliveArgs](_src_methods_balances_transferkeepalive_.md#balancestransferkeepaliveargs), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/balances/transferKeepAlive.ts:18](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/balances/transferKeepAlive.ts#L18)*
+*Defined in [src/methods/balances/transferKeepAlive.ts:18](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/balances/transferKeepAlive.ts#L18)*
 
 Construct a balance transfer transaction offline.
 

--- a/docs/modules/_src_methods_claims_attest_.md
+++ b/docs/modules/_src_methods_claims_attest_.md
@@ -18,7 +18,7 @@
 
 ▸ **attest**(`args`: [ClaimsAttestArgs](../interfaces/_src_methods_claims_attest_.claimsattestargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/claims/attest.ts:24](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/claims/attest.ts#L24)*
+*Defined in [src/methods/claims/attest.ts:24](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/claims/attest.ts#L24)*
 
 Attest to a statement, needed to finalize the claims process. This method is
 only available on Polkadot.

--- a/docs/modules/_src_methods_claims_claimattest_.md
+++ b/docs/modules/_src_methods_claims_claimattest_.md
@@ -18,7 +18,7 @@
 
 ▸ **claimAttest**(`args`: [ClaimsClaimAttestArgs](../interfaces/_src_methods_claims_claimattest_.claimsclaimattestargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/claims/claimAttest.ts:35](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/claims/claimAttest.ts#L35)*
+*Defined in [src/methods/claims/claimAttest.ts:35](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/claims/claimAttest.ts#L35)*
 
 Make a claim to collect your DOTs by signing a statement.
 

--- a/docs/modules/_src_methods_democracy_activateproxy_.md
+++ b/docs/modules/_src_methods_democracy_activateproxy_.md
@@ -18,7 +18,7 @@
 
 ▸ **activateProxy**(`args`: [DemocracyActivateProxyArgs](../interfaces/_src_methods_democracy_activateproxy_.democracyactivateproxyargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/activateProxy.ts:24](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/activateProxy.ts#L24)*
+*Defined in [src/methods/democracy/activateProxy.ts:24](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/activateProxy.ts#L24)*
 
 Specify a proxy that is already open to us. Called by the stash.
 

--- a/docs/modules/_src_methods_democracy_closeproxy_.md
+++ b/docs/modules/_src_methods_democracy_closeproxy_.md
@@ -14,7 +14,7 @@
 
 ▸ **closeProxy**(`args`: object, `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/closeProxy.ts:16](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/closeProxy.ts#L16)*
+*Defined in [src/methods/democracy/closeProxy.ts:16](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/closeProxy.ts#L16)*
 
 Clear the proxy. Called by the proxy.
 

--- a/docs/modules/_src_methods_democracy_deactivateproxy_.md
+++ b/docs/modules/_src_methods_democracy_deactivateproxy_.md
@@ -18,7 +18,7 @@
 
 ▸ **deactivateProxy**(`args`: [DemocracyDeactivateProxyArgs](../interfaces/_src_methods_democracy_deactivateproxy_.democracydeactivateproxyargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/deactivateProxy.ts:25](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/deactivateProxy.ts#L25)*
+*Defined in [src/methods/democracy/deactivateProxy.ts:25](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/deactivateProxy.ts#L25)*
 
 Deactivate the proxy, but leave open to this account. Called by the stash.
 The proxy must already be active.

--- a/docs/modules/_src_methods_democracy_openproxy_.md
+++ b/docs/modules/_src_methods_democracy_openproxy_.md
@@ -18,7 +18,7 @@
 
 ▸ **openProxy**(`args`: [DemocracyOpenProxyArgs](../interfaces/_src_methods_democracy_openproxy_.democracyopenproxyargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/openProxy.ts:24](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/openProxy.ts#L24)*
+*Defined in [src/methods/democracy/openProxy.ts:24](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/openProxy.ts#L24)*
 
 Become a proxy. This must be called prior to a later `activateProxy`.
 

--- a/docs/modules/_src_methods_democracy_proxyvote_.md
+++ b/docs/modules/_src_methods_democracy_proxyvote_.md
@@ -18,7 +18,7 @@
 
 ▸ **proxyVote**(`args`: [DemocracyProxyVoteArgs](../interfaces/_src_methods_democracy_proxyvote_.democracyproxyvoteargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/proxyVote.ts:29](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/proxyVote.ts#L29)*
+*Defined in [src/methods/democracy/proxyVote.ts:29](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/proxyVote.ts#L29)*
 
 Vote in a referendum on behalf of a stash.
 

--- a/docs/modules/_src_methods_democracy_types_.md
+++ b/docs/modules/_src_methods_democracy_types_.md
@@ -15,7 +15,7 @@
 
 Ƭ **AccountVote**: *object | object*
 
-*Defined in [src/methods/democracy/types.ts:26](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/types.ts#L26)*
+*Defined in [src/methods/democracy/types.ts:26](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/types.ts#L26)*
 
 A vote in a referendum. Can be one of:
 - Standard: A standard vote, one-way (approve or reject) with a given amount
@@ -29,7 +29,7 @@ ___
 
 Ƭ **Vote**: *object*
 
-*Defined in [src/methods/democracy/types.ts:7](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/types.ts#L7)*
+*Defined in [src/methods/democracy/types.ts:7](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/types.ts#L7)*
 
 A vote in a referendum
 

--- a/docs/modules/_src_methods_democracy_vote_.md
+++ b/docs/modules/_src_methods_democracy_vote_.md
@@ -18,7 +18,7 @@
 
 ▸ **vote**(`args`: [DemocracyVoteArgs](../interfaces/_src_methods_democracy_vote_.democracyvoteargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/democracy/vote.ts:28](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/democracy/vote.ts#L28)*
+*Defined in [src/methods/democracy/vote.ts:28](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/democracy/vote.ts#L28)*
 
 Vote in a referendum.
 

--- a/docs/modules/_src_methods_poll_vote_.md
+++ b/docs/modules/_src_methods_poll_vote_.md
@@ -18,7 +18,7 @@
 
 ▸ **vote**(`args`: [PollVoteArgs](../interfaces/_src_methods_poll_vote_.pollvoteargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/poll/vote.ts:23](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/poll/vote.ts#L23)*
+*Defined in [src/methods/poll/vote.ts:23](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/poll/vote.ts#L23)*
 
 Cast a vote on the poll.
 

--- a/docs/modules/_src_methods_proxy_addproxy_.md
+++ b/docs/modules/_src_methods_proxy_addproxy_.md
@@ -18,7 +18,7 @@
 
 ▸ **addProxy**(`args`: [ProxyAddProxy](../interfaces/_src_methods_proxy_addproxy_.proxyaddproxy.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/proxy/addProxy.ts:33](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/proxy/addProxy.ts#L33)*
+*Defined in [src/methods/proxy/addProxy.ts:33](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/proxy/addProxy.ts#L33)*
 
 Register a proxy account for the sender that is able to make calls on its behalf.
 

--- a/docs/modules/_src_methods_proxy_proxy_.md
+++ b/docs/modules/_src_methods_proxy_proxy_.md
@@ -18,7 +18,7 @@
 
 ▸ **proxy**(`args`: [ProxyProxy](../interfaces/_src_methods_proxy_proxy_.proxyproxy.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/proxy/proxy.ts:33](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/proxy/proxy.ts#L33)*
+*Defined in [src/methods/proxy/proxy.ts:33](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/proxy/proxy.ts#L33)*
 
 Dispatch the given `call` from an account for which the sender is authorized.
 

--- a/docs/modules/_src_methods_proxy_removeproxies_.md
+++ b/docs/modules/_src_methods_proxy_removeproxies_.md
@@ -14,7 +14,7 @@
 
 ▸ **removeProxies**(`args`: object, `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/proxy/removeProxies.ts:15](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/proxy/removeProxies.ts#L15)*
+*Defined in [src/methods/proxy/removeProxies.ts:15](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/proxy/removeProxies.ts#L15)*
 
 Unregister all proxy accounts for the sender.
 

--- a/docs/modules/_src_methods_proxy_removeproxy_.md
+++ b/docs/modules/_src_methods_proxy_removeproxy_.md
@@ -18,7 +18,7 @@
 
 ▸ **removeProxy**(`args`: [ProxyRemoveProxy](../interfaces/_src_methods_proxy_removeproxy_.proxyremoveproxy.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/proxy/removeProxy.ts:28](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/proxy/removeProxy.ts#L28)*
+*Defined in [src/methods/proxy/removeProxy.ts:28](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/proxy/removeProxy.ts#L28)*
 
 Unregister a proxy account for the sender.
 

--- a/docs/modules/_src_methods_session_setkeys_.md
+++ b/docs/modules/_src_methods_session_setkeys_.md
@@ -18,7 +18,7 @@
 
 ▸ **setKeys**(`args`: [SessionSetKeysArgs](../interfaces/_src_methods_session_setkeys_.sessionsetkeysargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/session/setKeys.ts:27](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/session/setKeys.ts#L27)*
+*Defined in [src/methods/session/setKeys.ts:27](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/session/setKeys.ts#L27)*
 
 Sets the session key(s) of the function caller to `key`.
 

--- a/docs/modules/_src_methods_staking_bond_.md
+++ b/docs/modules/_src_methods_staking_bond_.md
@@ -18,7 +18,7 @@
 
 ▸ **bond**(`args`: [StakingBondArgs](../interfaces/_src_methods_staking_bond_.stakingbondargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/bond.ts:31](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/bond.ts#L31)*
+*Defined in [src/methods/staking/bond.ts:31](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/bond.ts#L31)*
 
 Construct a transaction to bond funds and create a Stash account.
 

--- a/docs/modules/_src_methods_staking_bondextra_.md
+++ b/docs/modules/_src_methods_staking_bondextra_.md
@@ -18,7 +18,7 @@
 
 ▸ **bondExtra**(`args`: [StakingBondExtraArgs](../interfaces/_src_methods_staking_bondextra_.stakingbondextraargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/bondExtra.ts:26](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/bondExtra.ts#L26)*
+*Defined in [src/methods/staking/bondExtra.ts:26](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/bondExtra.ts#L26)*
 
 Add some extra amount that have appeared in the stash `free_balance` into
 the balance up for staking.

--- a/docs/modules/_src_methods_staking_chill_.md
+++ b/docs/modules/_src_methods_staking_chill_.md
@@ -14,7 +14,7 @@
 
 ▸ **chill**(`args`: object, `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/chill.ts:17](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/chill.ts#L17)*
+*Defined in [src/methods/staking/chill.ts:17](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/chill.ts#L17)*
 
 Declare the desire to cease validating or nominating. Does not unbond funds.
 

--- a/docs/modules/_src_methods_staking_nominate_.md
+++ b/docs/modules/_src_methods_staking_nominate_.md
@@ -18,7 +18,7 @@
 
 ▸ **nominate**(`args`: [StakingNominateArgs](../interfaces/_src_methods_staking_nominate_.stakingnominateargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/nominate.ts:28](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/nominate.ts#L28)*
+*Defined in [src/methods/staking/nominate.ts:28](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/nominate.ts#L28)*
 
 Construct a transaction to nominate. This must be called by the _Controller_ account.
 

--- a/docs/modules/_src_methods_staking_payoutnominator_.md
+++ b/docs/modules/_src_methods_staking_payoutnominator_.md
@@ -18,7 +18,7 @@
 
 ▸ **payoutNominator**(`args`: [StakingPayoutNominatorArgs](../interfaces/_src_methods_staking_payoutnominator_.stakingpayoutnominatorargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/payoutNominator.ts:36](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/payoutNominator.ts#L36)*
+*Defined in [src/methods/staking/payoutNominator.ts:36](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/payoutNominator.ts#L36)*
 
 Make one nominator's payout for one era.
 WARNING: once an era is payed for a validator such validator can't claim the

--- a/docs/modules/_src_methods_staking_payoutstakers_.md
+++ b/docs/modules/_src_methods_staking_payoutstakers_.md
@@ -18,7 +18,7 @@
 
 ▸ **payoutStakers**(`args`: [StakingPayoutStakersArgs](../interfaces/_src_methods_staking_payoutstakers_.stakingpayoutstakersargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/payoutStakers.ts:34](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/payoutStakers.ts#L34)*
+*Defined in [src/methods/staking/payoutStakers.ts:34](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/payoutStakers.ts#L34)*
 
 Pay out all the stakers behind a single validator for a single era.
 

--- a/docs/modules/_src_methods_staking_payoutvalidator_.md
+++ b/docs/modules/_src_methods_staking_payoutvalidator_.md
@@ -18,7 +18,7 @@
 
 ▸ **payoutValidator**(`args`: [StakingPayoutValidatorArgs](../interfaces/_src_methods_staking_payoutvalidator_.stakingpayoutvalidatorargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/payoutValidator.ts:29](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/payoutValidator.ts#L29)*
+*Defined in [src/methods/staking/payoutValidator.ts:29](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/payoutValidator.ts#L29)*
 
 Make one validator's payout for one era.
 WARNING: once an era is payed for a validator such validator can't claim the

--- a/docs/modules/_src_methods_staking_rebond_.md
+++ b/docs/modules/_src_methods_staking_rebond_.md
@@ -18,7 +18,7 @@
 
 ▸ **rebond**(`args`: [StakingRebondArgs](../interfaces/_src_methods_staking_rebond_.stakingrebondargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/rebond.ts:23](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/rebond.ts#L23)*
+*Defined in [src/methods/staking/rebond.ts:23](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/rebond.ts#L23)*
 
 Rebond a portion of the stash scheduled to be unlocked.
 

--- a/docs/modules/_src_methods_staking_setcontroller_.md
+++ b/docs/modules/_src_methods_staking_setcontroller_.md
@@ -18,7 +18,7 @@
 
 ▸ **setController**(`args`: [StakingSetControllerArgs](../interfaces/_src_methods_staking_setcontroller_.stakingsetcontrollerargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/setController.ts:24](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/setController.ts#L24)*
+*Defined in [src/methods/staking/setController.ts:24](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/setController.ts#L24)*
 
 (Re-)set the controller of a stash. Effects will be felt at the beginning of
 the next era.

--- a/docs/modules/_src_methods_staking_setpayee_.md
+++ b/docs/modules/_src_methods_staking_setpayee_.md
@@ -18,7 +18,7 @@
 
 ▸ **setPayee**(`args`: [StakingSetPayeeArgs](../interfaces/_src_methods_staking_setpayee_.stakingsetpayeeargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/setPayee.ts:27](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/setPayee.ts#L27)*
+*Defined in [src/methods/staking/setPayee.ts:27](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/setPayee.ts#L27)*
 
 (Re-)set the payment target for staking rewards.
 

--- a/docs/modules/_src_methods_staking_unbond_.md
+++ b/docs/modules/_src_methods_staking_unbond_.md
@@ -18,7 +18,7 @@
 
 ▸ **unbond**(`args`: [StakingUnbondArgs](../interfaces/_src_methods_staking_unbond_.stakingunbondargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/unbond.ts:26](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/unbond.ts#L26)*
+*Defined in [src/methods/staking/unbond.ts:26](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/unbond.ts#L26)*
 
 Construct a transaction to unbond funds from a Stash account. This must be
 called by the _Controller_ account.

--- a/docs/modules/_src_methods_staking_validate_.md
+++ b/docs/modules/_src_methods_staking_validate_.md
@@ -18,7 +18,7 @@
 
 ▸ **validate**(`args`: [StakingValidateArgs](../interfaces/_src_methods_staking_validate_.stakingvalidateargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/validate.ts:27](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/validate.ts#L27)*
+*Defined in [src/methods/staking/validate.ts:27](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/validate.ts#L27)*
 
 Declare the desire to validate for the origin controller.
 

--- a/docs/modules/_src_methods_staking_withdrawunbonded_.md
+++ b/docs/modules/_src_methods_staking_withdrawunbonded_.md
@@ -18,7 +18,7 @@
 
 ▸ **withdrawUnbonded**(`args`: [StakingWithdrawUnbondedArgs](../interfaces/_src_methods_staking_withdrawunbonded_.stakingwithdrawunbondedargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/staking/withdrawUnbonded.ts:22](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/staking/withdrawUnbonded.ts#L22)*
+*Defined in [src/methods/staking/withdrawUnbonded.ts:22](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/staking/withdrawUnbonded.ts#L22)*
 
 Remove any unlocked chunks from the `unlocking` queue from our management.
 

--- a/docs/modules/_src_methods_system_remark_.md
+++ b/docs/modules/_src_methods_system_remark_.md
@@ -18,7 +18,7 @@
 
 ▸ **remark**(`args`: [SystemRemarkArgs](../interfaces/_src_methods_system_remark_.systemremarkargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/system/remark.ts:23](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/system/remark.ts#L23)*
+*Defined in [src/methods/system/remark.ts:23](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/system/remark.ts#L23)*
 
 Make some on-chain remark.
 

--- a/docs/modules/_src_methods_utility_batch_.md
+++ b/docs/modules/_src_methods_utility_batch_.md
@@ -18,7 +18,7 @@
 
 ▸ **batch**(`args`: [UtilityBatch](../interfaces/_src_methods_utility_batch_.utilitybatch.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/utility/batch.ts:18](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/utility/batch.ts#L18)*
+*Defined in [src/methods/utility/batch.ts:18](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/utility/batch.ts#L18)*
 
 **Parameters:**
 

--- a/docs/modules/_src_methods_vesting_vest_.md
+++ b/docs/modules/_src_methods_vesting_vest_.md
@@ -14,7 +14,7 @@
 
 ▸ **vest**(`args`: object, `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/vesting/vest.ts:15](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/vesting/vest.ts#L15)*
+*Defined in [src/methods/vesting/vest.ts:15](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/vesting/vest.ts#L15)*
 
 Unlock any vested funds of the sender account.
 

--- a/docs/modules/_src_methods_vesting_vestother_.md
+++ b/docs/modules/_src_methods_vesting_vestother_.md
@@ -18,7 +18,7 @@
 
 ▸ **vestOther**(`args`: [VestingVestOtherArgs](../interfaces/_src_methods_vesting_vestother_.vestingvestotherargs.md), `info`: [BaseTxInfo](../interfaces/_src_util_types_.basetxinfo.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *[UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md)*
 
-*Defined in [src/methods/vesting/vestOther.ts:24](https://github.com/paritytech/txwrapper/blob/e82a68c/src/methods/vesting/vestOther.ts#L24)*
+*Defined in [src/methods/vesting/vestOther.ts:24](https://github.com/paritytech/txwrapper/blob/2e195b6/src/methods/vesting/vestOther.ts#L24)*
 
 Unlock any vested funds of a `target` account.
 

--- a/docs/modules/_src_util_claims_.md
+++ b/docs/modules/_src_util_claims_.md
@@ -19,7 +19,7 @@
 
 ▸ **getEthereumPayload**(`dest`: string, `statement`: [PolkadotStatement](../interfaces/_src_util_claims_.polkadotstatement.md), `options`: [OptionsWithMeta](../interfaces/_src_util_types_.optionswithmeta.md)): *string*
 
-*Defined in [src/util/claims.ts:61](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/claims.ts#L61)*
+*Defined in [src/util/claims.ts:61](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/claims.ts#L61)*
 
 Generate the payload that needs to be signed with the Ethereum key that made
 a claim. The returned signature is needed as argument for
@@ -41,7 +41,7 @@ ___
 
 ▸ **getPolkadotStatement**(`statementKind`: StatementKind | "Regular" | "Saft"): *[PolkadotStatement](../interfaces/_src_util_claims_.polkadotstatement.md)*
 
-*Defined in [src/util/claims.ts:32](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/claims.ts#L32)*
+*Defined in [src/util/claims.ts:32](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/claims.ts#L32)*
 
 Retrieve the statements to sign with `claims.claimAttest` and
 `claims.attest`. These statements are hardcoded in txwrapper.

--- a/docs/modules/_src_util_constants_.md
+++ b/docs/modules/_src_util_constants_.md
@@ -17,7 +17,7 @@
 
 • **EXTRINSIC_VERSION**: *4* = 4
 
-*Defined in [src/util/constants.ts:18](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/constants.ts#L18)*
+*Defined in [src/util/constants.ts:18](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/constants.ts#L18)*
 
 Latest extrinsic version.
 
@@ -27,7 +27,7 @@ ___
 
 • **KUSAMA_SS58_FORMAT**: *2* = 2
 
-*Defined in [src/util/constants.ts:4](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/constants.ts#L4)*
+*Defined in [src/util/constants.ts:4](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/constants.ts#L4)*
 
 Prefix for SS58-encoded addresses on Kusama.
 
@@ -37,7 +37,7 @@ ___
 
 • **POLKADOT_SS58_FORMAT**: *0* = 0
 
-*Defined in [src/util/constants.ts:8](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/constants.ts#L8)*
+*Defined in [src/util/constants.ts:8](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/constants.ts#L8)*
 
 Prefix for SS58-encoded addresses on Polkadot.
 
@@ -47,7 +47,7 @@ ___
 
 • **WESTEND_SS58_FORMAT**: *42* = 42
 
-*Defined in [src/util/constants.ts:13](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/constants.ts#L13)*
+*Defined in [src/util/constants.ts:13](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/constants.ts#L13)*
 
 Prefix for SS58-encoded addresses on Westend.
 Also the default for Substrate-based chains.

--- a/docs/modules/_src_util_encodeunsignedtx_.md
+++ b/docs/modules/_src_util_encodeunsignedtx_.md
@@ -14,7 +14,7 @@
 
 ▸ **encodeUnsignedTransaction**(`unsigned`: [UnsignedTransaction](../interfaces/_src_util_types_.unsignedtransaction.md), `options`: [Options](../interfaces/_src_util_types_.options.md)): *string*
 
-*Defined in [src/util/encodeUnsignedTx.ts:9](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/encodeUnsignedTx.ts#L9)*
+*Defined in [src/util/encodeUnsignedTx.ts:9](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/encodeUnsignedTx.ts#L9)*
 
 Encode an unsigned transaction to submit.
 

--- a/docs/modules/_src_util_metadata_.md
+++ b/docs/modules/_src_util_metadata_.md
@@ -18,7 +18,7 @@
 
 ▸ **getRegistry**(`chainName`: "Kusama" | "Polkadot" | "Polkadot CC1" | "Westend", `specName`: "kusama" | "polkadot" | "westend", `specVersion`: number, `metadataRpc?`: undefined | string): *TypeRegistry*
 
-*Defined in [src/util/metadata.ts:112](https://github.com/paritytech/txwrapper/blob/e82a68c/src/util/metadata.ts#L112)*
+*Defined in [src/util/metadata.ts:112](https://github.com/paritytech/txwrapper/blob/2e195b6/src/util/metadata.ts#L112)*
 
 Given a chain name, a spec name, and a spec version, return the
 corresponding type registry. This function only returns the correct type

--- a/examples/polkadot.ts
+++ b/examples/polkadot.ts
@@ -55,7 +55,7 @@ async function main(): Promise<void> {
   // if desired.
   const unsigned = methods.balances.transfer(
     {
-      value: 12,
+      value: '90071992547409910',
       dest: '14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3', // Bob
     },
     {
@@ -79,10 +79,14 @@ async function main(): Promise<void> {
   );
 
   // Decode an unsigned transaction.
-  const decodedUnsigned = decode(unsigned, {
-    metadataRpc,
-    registry,
-  });
+  const decodedUnsigned = decode(
+    unsigned,
+    {
+      metadataRpc,
+      registry,
+    },
+    true
+  );
   console.log(
     `\nDecoded Transaction\n  To: ${decodedUnsigned.method.args.dest}\n` +
       `  Amount: ${decodedUnsigned.method.args.value}`
@@ -93,10 +97,14 @@ async function main(): Promise<void> {
   console.log(`\nPayload to Sign: ${signingPayload}`);
 
   // Decode the information from a signing payload.
-  const payloadInfo = decode(signingPayload, {
-    metadataRpc,
-    registry,
-  });
+  const payloadInfo = decode(
+    signingPayload,
+    {
+      metadataRpc,
+      registry,
+    },
+    true
+  );
   console.log(
     `\nDecoded Transaction\n  To: ${payloadInfo.method.args.dest}\n` +
       `  Amount: ${payloadInfo.method.args.value}`
@@ -124,10 +132,14 @@ async function main(): Promise<void> {
   console.log(`Actual Tx Hash: ${actualTxHash}`);
 
   // Decode a signed payload.
-  const txInfo = decode(tx, {
-    metadataRpc,
-    registry,
-  });
+  const txInfo = decode(
+    tx,
+    {
+      metadataRpc,
+      registry,
+    },
+    true
+  );
   console.log(
     `\nDecoded Transaction\n  To: ${txInfo.method.args.dest}\n` +
       `  Amount: ${txInfo.method.args.value}\n`

--- a/src/decode/decode.ts
+++ b/src/decode/decode.ts
@@ -11,7 +11,7 @@ import { DecodedUnsignedTx, decodeUnsignedTx } from './decodeUnsignedTx';
  *
  * @param unsignedTx - The data to parse, as an unsigned tx.
  * @param options - Runtime-specific data used for decoding the transaction.
- * @param toInt - Wether or not to forcibly serialize integers in the call args
+ * @param toInt - Whether or not to forcibly serialize integers in the call args
  * to base-10 strings. If false, integers will either be a number or hex.
  * Defaults to false
  */
@@ -26,7 +26,7 @@ export function decode(
  *
  * @param signedTx - The data to parse, as a signed tx hex string.
  * @param options - Runtime-specific data used for decoding the transaction.
- * @param toInt - Wether or not to forcibly serialize integers in the call args
+ * @param toInt - Whether or not to forcibly serialize integers in the call args
  * to base-10 strings. If false, integers will either be a number or hex.
  * Defaults to false
  */
@@ -41,7 +41,7 @@ export function decode(
  *
  * @param signingPayload - The data to parse, as a signing payload hex string.
  * @param options - Runtime-specific data used for decoding the transaction.
- * @param toInt - Wether or not to forcibly serialize integers in the call args
+ * @param toInt - Whether or not to forcibly serialize integers in the call args
  * to base-10 strings. If false, integers will either be a number or hex.
  * Defaults to false
  */

--- a/src/decode/decode.ts
+++ b/src/decode/decode.ts
@@ -11,10 +11,14 @@ import { DecodedUnsignedTx, decodeUnsignedTx } from './decodeUnsignedTx';
  *
  * @param unsignedTx - The data to parse, as an unsigned tx.
  * @param options - Runtime-specific data used for decoding the transaction.
+ * @param toInt - Wether or not to forcibly serialize integers in the call args
+ * to base-10 strings. If false, integers will either be a number or hex.
+ * Defaults to false
  */
 export function decode(
   unsignedTx: UnsignedTransaction,
-  options: OptionsWithMeta
+  options: OptionsWithMeta,
+  toInt?: boolean
 ): DecodedUnsignedTx;
 
 /**
@@ -22,10 +26,14 @@ export function decode(
  *
  * @param signedTx - The data to parse, as a signed tx hex string.
  * @param options - Runtime-specific data used for decoding the transaction.
+ * @param toInt - Wether or not to forcibly serialize integers in the call args
+ * to base-10 strings. If false, integers will either be a number or hex.
+ * Defaults to false
  */
 export function decode(
   signedTx: string,
-  options: OptionsWithMeta
+  options: OptionsWithMeta,
+  toInt?: boolean
 ): DecodedSignedTx;
 
 /**
@@ -33,25 +41,30 @@ export function decode(
  *
  * @param signingPayload - The data to parse, as a signing payload hex string.
  * @param options - Runtime-specific data used for decoding the transaction.
+ * @param toInt - Wether or not to forcibly serialize integers in the call args
+ * to base-10 strings. If false, integers will either be a number or hex.
+ * Defaults to false
  */
 export function decode(
   signingPayload: string,
-  options: OptionsWithMeta
+  options: OptionsWithMeta,
+  toInt?: boolean
 ): DecodedSigningPayload;
 
 export function decode(
   data: string | UnsignedTransaction,
-  options: OptionsWithMeta
+  options: OptionsWithMeta,
+  toInt = false
 ): DecodedSignedTx | DecodedUnsignedTx | DecodedSigningPayload {
   if (typeof data === 'string') {
     let decodedInfo: DecodedSigningPayload | DecodedSignedTx;
     try {
-      decodedInfo = decodeSigningPayload(data, options);
+      decodedInfo = decodeSigningPayload(data, options, toInt);
     } catch {
-      decodedInfo = decodeSignedTx(data, options);
+      decodedInfo = decodeSignedTx(data, options, toInt);
     }
     return decodedInfo;
   }
 
-  return decodeUnsignedTx(data, options);
+  return decodeUnsignedTx(data, options, toInt);
 }

--- a/src/decode/decodeSignedTx.ts
+++ b/src/decode/decodeSignedTx.ts
@@ -24,7 +24,8 @@ export type DecodedSignedTx = Omit<
  */
 export function decodeSignedTx(
   signedTx: string,
-  options: OptionsWithMeta
+  options: OptionsWithMeta,
+  toInt = false
 ): DecodedSignedTx {
   const { metadataRpc, registry } = options;
 
@@ -34,7 +35,7 @@ export function decodeSignedTx(
     isSigned: true,
   });
   const methodCall = registry.createType('Call', tx.method);
-  const method = toTxMethod(registry, methodCall);
+  const method = toTxMethod(registry, methodCall, toInt);
 
   return {
     address: tx.signer.toString(),

--- a/src/decode/decodeSigningPayload.ts
+++ b/src/decode/decodeSigningPayload.ts
@@ -20,7 +20,8 @@ export type DecodedSigningPayload = Omit<TxInfo, 'address' | 'blockNumber'>;
  */
 export function decodeSigningPayload(
   signingPayload: string,
-  options: OptionsWithMeta
+  options: OptionsWithMeta,
+  toInt = false
 ): DecodedSigningPayload {
   const { metadataRpc, registry } = options;
 
@@ -30,7 +31,7 @@ export function decodeSigningPayload(
     version: EXTRINSIC_VERSION,
   });
   const methodCall = registry.createType('Call', payload.method);
-  const method = toTxMethod(registry, methodCall);
+  const method = toTxMethod(registry, methodCall, toInt);
 
   return {
     blockHash: payload.blockHash.toHex(),

--- a/src/decode/decodeUnsignedTx.ts
+++ b/src/decode/decodeUnsignedTx.ts
@@ -20,14 +20,15 @@ export type DecodedUnsignedTx = TxInfo;
  */
 export function decodeUnsignedTx(
   unsigned: UnsignedTransaction,
-  options: OptionsWithMeta
+  options: OptionsWithMeta,
+  toInt = false
 ): DecodedUnsignedTx {
   const { metadataRpc, registry } = options;
 
   registry.setMetadata(createMetadata(registry, metadataRpc));
 
   const methodCall = registry.createType('Call', unsigned.method);
-  const method = toTxMethod(registry, methodCall);
+  const method = toTxMethod(registry, methodCall, toInt);
 
   return {
     address: unsigned.address,

--- a/src/util/method.ts
+++ b/src/util/method.ts
@@ -146,7 +146,7 @@ export function toTxMethod(
       codec = codec.unwrap() as Codec;
     }
 
-    // Forcibly serialize all integers to strings
+    // Forcibly serialize all integers to strings if toInt is true
     const jsonArg =
       toInt && codec instanceof AbstractInt
         ? codec.toString(10)

--- a/src/util/method.ts
+++ b/src/util/method.ts
@@ -125,7 +125,7 @@ export function createMethod(
  *
  * @param registry - The type registry
  * @param method - The method to serialize
- * @param toInt - Wether or not to forcibly serialize integers in the call args
+ * @param toInt - Whether or not to forcibly serialize integers in the call args
  * to base-10 strings. If false, integers will either be a number or hex.
  * Defaults to false
  */

--- a/src/util/method.ts
+++ b/src/util/method.ts
@@ -141,7 +141,7 @@ export function toTxMethod(
   const args = Object.keys(argsDef).reduce((accumulator, key, index) => {
     let codec = createTypeUnsafe(registry, argsDef[key], [method.args[index]]);
 
-    if (codec instanceof Compact) {
+    if (toInt && codec instanceof Compact) {
       // Unwrap the compact so we can check the interior type
       codec = codec.unwrap() as Codec;
     }

--- a/src/util/method.ts
+++ b/src/util/method.ts
@@ -2,10 +2,11 @@
 /**
  * @ignore
  */ /** */
-
 import { createTypeUnsafe, TypeRegistry } from '@polkadot/types';
+import { Compact } from '@polkadot/types';
+import AbstractInt from '@polkadot/types/codec/AbstractInt';
 import { Call } from '@polkadot/types/interfaces';
-import { AnyJson } from '@polkadot/types/types';
+import { AnyJson, Codec } from '@polkadot/types/types';
 import { stringCamelCase } from '@polkadot/util';
 
 import { EXTRINSIC_VERSION } from './constants';
@@ -124,18 +125,34 @@ export function createMethod(
  *
  * @param registry - The type registry
  * @param method - The method to serialize
+ * @param toInt - Wether or not to forcibly serialize integers in the call args
+ * to base-10 strings. If false, integers will either be a number or hex.
+ * Defaults to false
  */
-export function toTxMethod(registry: TypeRegistry, method: Call): TxMethod {
+export function toTxMethod(
+  registry: TypeRegistry,
+  method: Call,
+  toInt = false
+): TxMethod {
   // Mapping of argName->argType
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const argsDef = JSON.parse(method.Type.args);
   // Mapping of argName->argValue
   const args = Object.keys(argsDef).reduce((accumulator, key, index) => {
-    const codec = createTypeUnsafe(registry, argsDef[key], [
-      method.args[index],
-    ]);
+    let codec = createTypeUnsafe(registry, argsDef[key], [method.args[index]]);
 
-    accumulator[stringCamelCase(key)] = codec.toJSON();
+    if (codec instanceof Compact) {
+      // Unwrap the compact so we can check the interior type
+      codec = codec.unwrap() as Codec;
+    }
+
+    // Forcibly serialize all integers to strings
+    const jsonArg =
+      toInt && codec instanceof AbstractInt
+        ? codec.toString(10)
+        : codec.toJSON();
+
+    accumulator[stringCamelCase(key)] = jsonArg;
     return accumulator;
   }, {} as Args);
 


### PR DESCRIPTION
This PR adds a `toInt` flag to all `decode` methods and to `toTxMethod`. 

In `toTxMethod`, if `toInt` is true, we check for any user supplied arguments to the Call that are instances of `AbstractInt`. When an `AbstractInt` is found it is serialized to base-10 string using the BN.js method `.toString(10)`. For simplicity sake, the current implementation checks inside of `Compact` types but does not check any other nested type. 

All decode methods rely on `toTxMethod`, so the decode methods now accept an optional `toInt` flag and simply thread it down to `toTxMethod`.

I also changed the `examples/polkadot.ts` to show the usage of the flag by using the JS max safe integer and adding a zero to the end (a number that polkadot.js would normally serialize to hex) and then passing in true for all the decode methods.