### PR TITLE
fix: bond and bondExtra value type number or string

### DIFF
--- a/src/methods/staking/bond.ts
+++ b/src/methods/staking/bond.ts
@@ -14,7 +14,7 @@ export interface StakingBondArgs extends Args {
   /**
    * The number of tokens to bond.
    */
-  value: number;
+  value: number | string;
   /**
    * The rewards destination. Can be "Stash", "Staked", or "Controller".
    */

--- a/src/methods/staking/bondExtra.ts
+++ b/src/methods/staking/bondExtra.ts
@@ -10,7 +10,7 @@ export interface StakingBondExtraArgs extends Args {
   /**
    * The maximum amount to bond.
    */
-  maxAdditional: number;
+  maxAdditional: number | string;
 }
 
 /**


### PR DESCRIPTION
Small change to allow strings pass a TS compiler check when `value` needs to be a string to work beyond the safe integer.