### PR TITLE
fix: Update `RewardDestination` for `staking.setPayee`

### DIFF
--- a/examples/polkadot.ts
+++ b/examples/polkadot.ts
@@ -53,11 +53,10 @@ async function main(): Promise<void> {
   // Now we can create our `balances.transfer` unsigned tx. The following
   // function takes the above data as arguments, so can be performed offline
   // if desired.
-  const unsigned = methods.staking.bond(
+  const unsigned = methods.balances.transfer(
     {
       value: '90071992547409910',
-      controller: '14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3', // Bob
-      payee: 'Controller',
+      dest: '14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3', // Bob
     },
     {
       address: deriveAddress(alice.publicKey, POLKADOT_SS58_FORMAT),

--- a/examples/polkadot.ts
+++ b/examples/polkadot.ts
@@ -53,10 +53,11 @@ async function main(): Promise<void> {
   // Now we can create our `balances.transfer` unsigned tx. The following
   // function takes the above data as arguments, so can be performed offline
   // if desired.
-  const unsigned = methods.balances.transfer(
+  const unsigned = methods.staking.bond(
     {
       value: '90071992547409910',
-      dest: '14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3', // Bob
+      controller: '14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3', // Bob
+      payee: 'Controller',
     },
     {
       address: deriveAddress(alice.publicKey, POLKADOT_SS58_FORMAT),
@@ -77,6 +78,8 @@ async function main(): Promise<void> {
       registry,
     }
   );
+
+  console.log('method: ', unsigned.method);
 
   // Decode an unsigned transaction.
   const decodedUnsigned = decode(

--- a/examples/polkadot.ts
+++ b/examples/polkadot.ts
@@ -78,8 +78,6 @@ async function main(): Promise<void> {
     }
   );
 
-  console.log('method: ', unsigned.method);
-
   // Decode an unsigned transaction.
   const decodedUnsigned = decode(
     unsigned,

--- a/src/methods/staking/bond.ts
+++ b/src/methods/staking/bond.ts
@@ -1,12 +1,12 @@
 import {
-  Args,
   BaseTxInfo,
   createMethod,
   OptionsWithMeta,
   UnsignedTransaction,
 } from '../../util';
+import { StakingSetPayeeArgs } from './setPayee';
 
-export interface StakingBondArgs extends Args {
+export interface StakingBondArgs extends StakingSetPayeeArgs {
   /**
    * The SS-58 encoded address of the Controller account.
    */
@@ -15,10 +15,6 @@ export interface StakingBondArgs extends Args {
    * The number of tokens to bond.
    */
   value: number | string;
-  /**
-   * The rewards destination. Can be "Stash", "Staked", "Controller" or "{ Account: accountId }"".
-   */
-  payee: string | { Account: string };
 }
 
 /**

--- a/src/methods/staking/setPayee.ts
+++ b/src/methods/staking/setPayee.ts
@@ -8,9 +8,9 @@ import {
 
 export interface StakingSetPayeeArgs extends Args {
   /**
-   * The `RewardDestination`. It can be one of 'Staking', 'Stash', or 'Controller'.
+   * The rewards destination. Can be "Stash", "Staked", "Controller" or "{ Account: accountId }"".
    */
-  payee: string;
+  payee: string | { Account: string };
 }
 
 /**


### PR DESCRIPTION
This updates `staking.setPayee` arguments to make sure that TS accepts `RewardDestination::Account` variant.

<img width="1273" alt="Screen Shot 2021-02-22 at 2 46 21 PM" src="https://user-images.githubusercontent.com/32168567/108780749-b8cee400-751d-11eb-9634-63bb758b1b57.png">

<img width="1444" alt="Screen Shot 2021-02-22 at 2 44 59 PM" src="https://user-images.githubusercontent.com/32168567/108780818-ce440e00-751d-11eb-8f86-dd52ecffa054.png">