### PR TITLE
fix(docs): `createSigningPayload` docs specify handling payloads > 256 bytes

### DIFF
--- a/src/createSigningPayload.ts
+++ b/src/createSigningPayload.ts
@@ -34,8 +34,16 @@ import { Options, UnsignedTransaction } from './util';
  *  });
  *
  * // With the `ExtrinsicPayload` class, construct the actual payload to sign.
- * const actualPayload = extrinsicPayload.toU8a({ method: true });
+ * // N.B. signing payloads > 256 bytes get hashed with blake2_256
+ * // ref: https://substrate.dev/rustdocs/v3.0.0/src/sp_runtime/generic/unchecked_extrinsic.rs.html#201-209
+ * extrinsicPayloadU8a = extrinsicPayload.toU8a({ method: true })
+ * const actualPayload = extrinsicPayloadU8a.length > 256
+ *   ? registry.hash(extrinsicPayloadU8a)
+ *   : extrinsicPayloadU8a;
+ *
  * // You can now sign `actualPayload` with you private key.
+ * // Note: you can can use `u8ToHex` from @polkadot/util to convert `actualPayload`
+ * // to a hex string.
  *
  * // Alternatively, call the `.sign()` method directly on the
  * `ExtrinsicPayload` class.


### PR DESCRIPTION
Fix docs for `createSigingPayload` to explain how to correctly handling singing payloads greater than 256 bytes.

This is especially important for users who do not use the `ExtrinsicPayload.sign` instance method.

Possibly relates to #263

relates to https://github.com/paritytech/txwrapper-core/pull/65