### PR TITLE
docs: Notes this package will be phased out

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@
 
 ## Note
 
-If you are a chain builder looking to build a chain specific `txwrapper` please take a look at [`txwrapper-core`](https://github.com/paritytech/txwrapper-core) and the [guide for chain builders](https://github.com/paritytech/txwrapper-core/blob/main/CHAIN_BUILDER.md). Any feedback is welcome, just make [an issue at that repo](https://github.com/paritytech/txwrapper-core/issues).
+Please use [`txwrapper-polkadot`](https://github.com/paritytech/txwrapper-core/tree/main/packages/txwrapper-polkadot) instead of this package for long term support and more features. This package will be phased out in the future in favor of the packages in [`txwrapper-core`](https://github.com/paritytech/txwrapper-core/).
+
+If you are a chain builder looking to build a chain specific `txwrapper` please take a look at [`txwrapper-core`](https://github.com/paritytech/txwrapper-core) and the [guide for chain builders](https://github.com/paritytech/txwrapper-core/blob/main/CHAIN_BUILDER.md). 
+
+Any feedback for txwrapper-core and the transition from this package is welcome, just make [an issue at that repo](https://github.com/paritytech/txwrapper-core/issues).
 
 ## Get Started
 


### PR DESCRIPTION
This PR updates the README.md to direct users over to `txwrapper-polkadot` as a direct replacement for this package.